### PR TITLE
fix spacing below country select component

### DIFF
--- a/clients/onboarding/src/components/CountryPicker.tsx
+++ b/clients/onboarding/src/components/CountryPicker.tsx
@@ -26,6 +26,7 @@ type CountrySelectProps<T extends CountryCCA3> = {
   items: CountryItem<T>[];
   holderType: "individual" | "company";
   onlyIconHelp: boolean;
+  hideError?: boolean;
 };
 
 export function OnboardingCountryPicker<T extends CountryCCA3>({
@@ -35,6 +36,7 @@ export function OnboardingCountryPicker<T extends CountryCCA3>({
   items,
   holderType,
   onlyIconHelp,
+  hideError,
 }: CountrySelectProps<T>) {
   return (
     <LakeLabel
@@ -43,7 +45,7 @@ export function OnboardingCountryPicker<T extends CountryCCA3>({
         <CountryPicker
           items={items}
           value={value}
-          hideErrors={true}
+          hideErrors={hideError}
           onValueChange={onValueChange}
         />
       )}

--- a/clients/onboarding/src/pages/v2company/OnboardingCompanyBasicInfo.tsx
+++ b/clients/onboarding/src/pages/v2company/OnboardingCompanyBasicInfo.tsx
@@ -176,6 +176,7 @@ export const OnboardingCompanyBasicInfo = ({ nextStep, onboardingId, initialValu
                       onValueChange={onChange}
                       holderType="company"
                       onlyIconHelp={small}
+                      hideError={true}
                     />
                   )}
                 </Field>


### PR DESCRIPTION
This PR brings a little UI improvement: it makes spacing below country select more consistent with the rest of the form: 

Before:  
![image](https://user-images.githubusercontent.com/32013054/228574652-606880fb-6dcb-4184-8d12-a0ab37928dc2.png)

After:  
![image](https://user-images.githubusercontent.com/32013054/228574458-de9e9963-ef6d-4bfd-ac2a-d3d71a9f5c77.png)

I keep the prop `hideError` because we need it for company initial step to create consistent spacing with radio group (which hasn't any error spacing)  
![image](https://user-images.githubusercontent.com/32013054/228575036-053d201e-88b0-4dd5-a957-c5081f62bf1d.png)
