### PR TITLE
remove "@graphql-codegen/typescript-graphql-request": "4.5.8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@graphql-codegen/introspection": "3.0.1",
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
-    "@graphql-codegen/typescript-graphql-request": "4.5.8",
+    "@graphql-codegen/typescript-graphql-request": "4.5.9",
     "@graphql-codegen/typescript-operations": "3.0.2",
     "@graphql-codegen/typescript-urql-graphcache": "2.4.4",
     "@lokalise/node-api": "9.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,16 +1447,6 @@
     change-case-all "1.0.15"
     tslib "~2.5.0"
 
-"@graphql-codegen/typescript-graphql-request@4.5.8":
-  version "4.5.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-4.5.8.tgz#55a609de168f4bf7b66f353b7ba4b1a21113c921"
-  integrity sha512-XsuAA35Ou03LsklNgnIWXZ5HOHsJ5w1dBuDKtvqM9rD0cAI8x0f4TY0n6O1EraSBSvyHLP3npb1lOTPZzG2TjA==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.7.2"
-    "@graphql-codegen/visitor-plugin-common" "2.13.1"
-    auto-bind "~4.0.0"
-    tslib "~2.4.0"
-
 "@graphql-codegen/typescript-graphql-request@4.5.9":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-4.5.9.tgz#d8a9488b7419cabf2ca98ae3936e82b9d244f2e9"


### PR DESCRIPTION
In a previous PR https://github.com/swan-io/swan-partner-frontend/pull/26, I made a mistake and we have 2 versions of `@graphql-codegen/typescript-graphql-request` in `yarn.lock`: 
- 4.5.8
- 4.5.9

This MR removes `4.5.8` and we keep only `4.5.9`
