### PR TITLE
fix statement order list padding

### DIFF
--- a/clients/banking/src/components/AccountStatementList.tsx
+++ b/clients/banking/src/components/AccountStatementList.tsx
@@ -20,6 +20,8 @@ const styles = StyleSheet.create({
   root: {
     height: 300,
     overflow: "hidden",
+    borderTopColor: colors.gray[100],
+    borderTopWidth: 1,
   },
   cellContainerLarge: {
     paddingLeft: spacings[24],


### PR DESCRIPTION
This PR concerns account statements modal. The goal is aligning close icon with open icons in the list.  
One part of me doesn't like to use values outside `spacing` union type.  
But finally I succeed to a result I prefer by using custom values.  
What do you think? Have you got another idea about how to achieve this in a better way?  
Here are before after screen shots:

### Mobile
![image](https://user-images.githubusercontent.com/32013054/228847967-d9aab609-1e2e-4334-9319-c67925442f15.png)

![image](https://user-images.githubusercontent.com/32013054/228847842-a8a65d2c-758f-4289-97d0-4368b6e56822.png)

### Desktop
![image](https://user-images.githubusercontent.com/32013054/228848059-a8f32f48-8966-4a11-b191-c1576c374ba0.png)

![image](https://user-images.githubusercontent.com/32013054/228848125-4846822f-0750-4d6f-811e-8a9ee53b02cf.png)
