### PR TITLE
Remove onAddFilter workaround

### DIFF
--- a/clients/banking/src/components/RecurringTransferList.tsx
+++ b/clients/banking/src/components/RecurringTransferList.tsx
@@ -711,12 +711,7 @@ export const RecurringTransferList = ({
               openFilters={openFilters}
               label={t("common.filters")}
               title={t("common.chooseFilter")}
-              onAddFilter={filter => {
-                if (filter === "canceled") {
-                  setFilters(filters => ({ ...filters, canceled: true }));
-                }
-                setOpenFilters(openFilters => [...openFilters, filter]);
-              }}
+              onAddFilter={filter => setOpenFilters(openFilters => [...openFilters, filter])}
               large={large}
             />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,7 +2375,7 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
-"@types/testing-library__jest-dom@^5.9.1":
+"@types/testing-library__jest-dom@^5.9.1", "@types/testing-library__jest-dom@github:zoontek/types-testing-library-vitest-dom":
   version "5.14.5"
   resolved "https://codeload.github.com/zoontek/types-testing-library-vitest-dom/tar.gz/0a0de96e76b403e1808429506fad50f90d28fced"
 


### PR DESCRIPTION
Since @swan-io/lake has been updated to 1.7.0, we can remove the `onAddFilter` workaround for boolean type filters.

See https://github.com/swan-io/lake/pull/35