### PR TITLE
Add shipping address to physical card in web banking

### DIFF
--- a/clients/banking/src/components/CardItemPhysicalDetails.tsx
+++ b/clients/banking/src/components/CardItemPhysicalDetails.tsx
@@ -21,7 +21,11 @@ import { showToast } from "@swan-io/lake/src/state/toasts";
 import { nullishOrEmptyToUndefined } from "@swan-io/lake/src/utils/nullish";
 import { CountryPicker } from "@swan-io/shared-business/src/components/CountryPicker";
 import { GMapAddressSearchInput } from "@swan-io/shared-business/src/components/GMapAddressSearchInput";
-import { CountryCCA3, countries } from "@swan-io/shared-business/src/constants/countries";
+import {
+  CountryCCA3,
+  countries,
+  getCountryNameByCCA3,
+} from "@swan-io/shared-business/src/constants/countries";
 import { useState } from "react";
 import { Image, StyleSheet, View } from "react-native";
 import { combineValidators, hasDefinedKeys, useForm } from "react-ux-form";
@@ -869,6 +873,34 @@ export const CardItemPhysicalDetails = ({
                       </>
                     );
                   },
+                )
+                .otherwise(() => null)}
+
+              {match(physicalCard.statusInfo)
+                .with(
+                  { __typename: "PhysicalCardToActivateStatusInfo" },
+                  { __typename: "PhysicalCardRenewedStatusInfo" },
+                  ({ address }) => (
+                    <>
+                      <LakeAlert
+                        variant={"info"}
+                        title={t("card.shippingAddress")}
+                        subtitle={[
+                          address.addressLine1,
+                          address.addressLine2,
+                          address.postalCode,
+                          address.city,
+                          address.country != null
+                            ? getCountryNameByCCA3(address.country)
+                            : undefined,
+                        ]
+                          .filter(Boolean)
+                          .join(", ")}
+                      />
+
+                      <Space height={24} />
+                    </>
+                  ),
                 )
                 .otherwise(() => null)}
 

--- a/clients/banking/src/locales/en.json
+++ b/clients/banking/src/locales/en.json
@@ -155,6 +155,7 @@
   "card.settings.withdrawal": "Withdrawal",
   "card.settings.withdrawal.description": "Allow withdrawals at ATMs",
   "card.shipping": "Shipping",
+  "card.shippingAddress": "Shipping address",
   "card.spendingLimit": "Spending limit",
   "card.spendingLimit.remaining.always": "Remaining (all time)",
   "card.spendingLimit.remaining.daily": "Remaining (next 24 hours)",


### PR DESCRIPTION
With `renewed` and `toActivate` status, add the shipping address in a info alert on the physical card tab in the web banking


https://user-images.githubusercontent.com/58843948/231113857-9a55e527-d060-4472-8ac1-fc39240ea1c4.mov

