### PR TITLE
Refacto TCU checkbox container

### DIFF
--- a/clients/onboarding/src/components/FinalizeStepBlocks.tsx
+++ b/clients/onboarding/src/components/FinalizeStepBlocks.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
   },
   tcu: {
     paddingHorizontal: spacings[24],
-    margin: "auto",
+    marginHorizontal: "auto",
   },
   tcuCheckbox: {
     top: 3, // center checkbox with text
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
   tcuLinkIcon: {
     marginLeft: spacings[4],
     display: "inline-block",
-    textAlignVertical: "center",
+    verticalAlign: "middle",
   },
 });
 


### PR DESCRIPTION
This PR is only technical and impacts the accept TCU checkbox in the last onboarding step (only for german account).  
It's just about center block, it replace `<Box alignItems="center">` by a css rule `margin: "auto"`.  
Here is the impacted screen:  

![image](https://user-images.githubusercontent.com/32013054/231370769-79b95d30-7bb6-4305-afa2-f8cf277e0647.png)
