### PR TITLE
change canceled card row UI

### DIFF
--- a/clients/banking/src/components/CardList.tsx
+++ b/clients/banking/src/components/CardList.tsx
@@ -2,8 +2,11 @@ import { Option } from "@swan-io/boxed";
 import { LinkConfig } from "@swan-io/lake/src/components/FixedListView";
 import { SimpleHeaderCell } from "@swan-io/lake/src/components/FixedListViewCells";
 import { ColumnConfig, PlainListView } from "@swan-io/lake/src/components/PlainListView";
+import { colors } from "@swan-io/lake/src/constants/design";
 import { useResponsive } from "@swan-io/lake/src/hooks/useResponsive";
 import { ReactElement, ReactNode, useState } from "react";
+import { StyleSheet } from "react-native";
+import { match } from "ts-pattern";
 import { CardListItemFragment } from "../graphql/partner";
 import { t } from "../utils/i18n";
 import { CardCancelConfirmationModal } from "./CardCancelConfirmationModal";
@@ -15,6 +18,12 @@ import {
   CardSummaryCell,
   FullNameAndCardTypeCell,
 } from "./CardListCells";
+
+const styles = StyleSheet.create({
+  canceledRow: {
+    backgroundColor: colors.gray[50],
+  },
+});
 
 type Props = {
   cards: { node: CardListItemFragment }[];
@@ -119,6 +128,11 @@ export const CardList = ({
         activeRowId={activeRowId}
         smallColumns={smallColumns}
         onEndReached={onEndReached}
+        rowStyle={({ statusInfo }) =>
+          match(statusInfo.status)
+            .with("Canceling", "Canceled", () => styles.canceledRow)
+            .otherwise(() => null)
+        }
         getRowLink={getRowLink}
         loading={loading}
         renderEmptyList={renderEmptyList}

--- a/clients/banking/src/components/CardListCells.tsx
+++ b/clients/banking/src/components/CardListCells.tsx
@@ -58,9 +58,6 @@ const styles = StyleSheet.create({
     ...commonStyles.fill,
     flexDirection: "column",
   },
-  tags: {
-    flexDirection: "row",
-  },
   spendingContainer: {
     ...commonStyles.fill,
   },
@@ -86,9 +83,6 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     borderRadius: 1,
-  },
-  dimmed: {
-    opacity: 0.4,
   },
 });
 
@@ -127,7 +121,7 @@ export const FullNameAndCardTypeCell = ({ card }: { card: Card }) => {
 
         <Space height={8} />
 
-        <View style={styles.tags}>
+        <Box direction="row">
           {match(card.type)
             .with("SingleUseVirtual", () => (
               <>
@@ -159,7 +153,7 @@ export const FullNameAndCardTypeCell = ({ card }: { card: Card }) => {
               </Tag>
             ))
             .exhaustive()}
-        </View>
+        </Box>
       </View>
     </View>
   );
@@ -245,7 +239,7 @@ export const CardStatusCell = ({ card }: { card: Card }) => {
         .with(
           { statusInfo: { __typename: "CardCanceledStatusInfo" } },
           { statusInfo: { __typename: "CardCancelingStatusInfo" } },
-          () => <Tag color="gray">{t("cardList.status.Canceled")}</Tag>,
+          () => <Tag color="negative">{t("cardList.status.Canceled")}</Tag>,
         )
         .with(
           { statusInfo: { __typename: "CardEnabledStatusInfo" } },
@@ -260,18 +254,7 @@ export const CardStatusCell = ({ card }: { card: Card }) => {
 export const CardSummaryCell = ({ card }: { card: Card }) => {
   const spendingLimits = card.spendingLimits ?? [];
   return (
-    <View
-      style={[
-        styles.cell,
-        match(card)
-          .with(
-            { statusInfo: { __typename: "CardCanceledStatusInfo" } },
-            { statusInfo: { __typename: "CardCancelingStatusInfo" } },
-            () => styles.dimmed,
-          )
-          .otherwise(() => null),
-      ]}
-    >
+    <View style={styles.cell}>
       <View>
         <Image source={{ uri: card.cardDesignUrl }} style={styles.cardDesignSmall} />
 
@@ -340,7 +323,20 @@ export const CardSummaryCell = ({ card }: { card: Card }) => {
         ) : null}
       </View>
 
-      <View style={styles.tags}>
+      <Box direction="row">
+        {match(card)
+          .with(
+            { statusInfo: { __typename: "CardCanceledStatusInfo" } },
+            { statusInfo: { __typename: "CardCancelingStatusInfo" } },
+            () => (
+              <>
+                <Tag color="negative" icon="subtract-circle-regular" />
+                <Space width={12} />
+              </>
+            ),
+          )
+          .otherwise(() => null)}
+
         {match(card.type)
           .with("SingleUseVirtual", () => (
             <>
@@ -370,7 +366,7 @@ export const CardSummaryCell = ({ card }: { card: Card }) => {
             />
           ))
           .exhaustive()}
-      </View>
+      </Box>
 
       <Space width={12} />
       <Icon name="chevron-right-filled" size={16} color={colors.gray[500]} />

--- a/clients/banking/src/graphql/partner.gql
+++ b/clients/banking/src/graphql/partner.gql
@@ -496,6 +496,7 @@ fragment CardListItem on Card {
   type
   name
   statusInfo {
+    __typename
     status
   }
   spendingLimits {


### PR DESCRIPTION
This PR depends on https://github.com/swan-io/lake/pull/49  

This PR impact card list, only the design of canceled cards:
- background color is gray[50]
- the canceled tag is red instead of gray
- on mobile we didn't reduce opacity anymore

1️⃣  Desktop changes
Before:  
![image](https://user-images.githubusercontent.com/32013054/233583459-355ebfe9-850d-4ebe-8d94-90315713f281.png)
After:  
![image](https://user-images.githubusercontent.com/32013054/233583733-09c24d4f-647b-4c39-9b03-a6e82593dd68.png)

2️⃣ Mobile changes
Before:  
![image](https://user-images.githubusercontent.com/32013054/233584506-e03edebb-a959-4ed0-98cd-c3dac78deea4.png)

After:  
![image](https://user-images.githubusercontent.com/32013054/233584234-ef619551-0c5f-4959-bfe4-7e3e4bfb9cff.png)
