### PR TITLE
Add a condition to not display the account activation step "initiate a first transfer"

### DIFF
--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -198,7 +198,8 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
 
   const requireFirstTransfer =
     account?.country === "FRA" &&
-    (user?.identificationLevels?.PVID === false || user?.identificationLevels?.QES === false);
+    user?.identificationLevels?.PVID === false &&
+    user?.identificationLevels?.QES === false;
 
   const documentCollection = holder?.supportingDocumentCollections.edges[0]?.node;
   const documentCollectionStatus = documentCollection?.statusInfo.status;

--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -196,6 +196,11 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
     typeof value === "boolean" ? Option.Some(value) : Option.None(),
   ).some(isValid => isValid);
 
+  const hasPvidOrQesValidation =
+    account?.country === "FRA" &&
+    (user?.identificationLevels?.PVID === true || user?.identificationLevels?.QES === true);
+  console.log("hasValidPvidVerification", hasPvidOrQesValidation);
+
   const documentCollection = holder?.supportingDocumentCollections.edges[0]?.node;
   const documentCollectionStatus = documentCollection?.statusInfo.status;
 
@@ -797,6 +802,7 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
                               )
                               .with({ name: "AccountActivation" }, () => (
                                 <AccountActivationPage
+                                  hasPvidOrQesValidation={hasPvidOrQesValidation}
                                   accentColor={accentColor}
                                   accountMembershipId={accountMembershipId}
                                   additionalInfo={additionalInfo}

--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -196,9 +196,9 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
     typeof value === "boolean" ? Option.Some(value) : Option.None(),
   ).some(isValid => isValid);
 
-  const hasPvidOrQesValidation =
+  const requireFirstTransfer =
     account?.country === "FRA" &&
-    (user?.identificationLevels?.PVID === true || user?.identificationLevels?.QES === true);
+    (user?.identificationLevels?.PVID === false || user?.identificationLevels?.QES === false);
 
   const documentCollection = holder?.supportingDocumentCollections.edges[0]?.node;
   const documentCollectionStatus = documentCollection?.statusInfo.status;
@@ -801,7 +801,7 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
                               )
                               .with({ name: "AccountActivation" }, () => (
                                 <AccountActivationPage
-                                  hasPvidOrQesValidation={hasPvidOrQesValidation}
+                                  requireFirstTransfer={requireFirstTransfer}
                                   accentColor={accentColor}
                                   accountMembershipId={accountMembershipId}
                                   additionalInfo={additionalInfo}

--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -199,7 +199,6 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
   const hasPvidOrQesValidation =
     account?.country === "FRA" &&
     (user?.identificationLevels?.PVID === true || user?.identificationLevels?.QES === true);
-  console.log("hasValidPvidVerification", hasPvidOrQesValidation);
 
   const documentCollection = holder?.supportingDocumentCollections.edges[0]?.node;
   const documentCollectionStatus = documentCollection?.statusInfo.status;

--- a/clients/banking/src/pages/AccountActivationPage.tsx
+++ b/clients/banking/src/pages/AccountActivationPage.tsx
@@ -639,7 +639,7 @@ export const AccountActivationPage = ({
         </Box>
       </StepScrollView>
     ))
-    .with("StepNotDisplayed", () => <></>)
+    .with("StepNotDisplayed", () => null)
     .exhaustive();
 
   return (

--- a/clients/banking/src/pages/AccountActivationPage.tsx
+++ b/clients/banking/src/pages/AccountActivationPage.tsx
@@ -250,6 +250,8 @@ const StepTile = ({ variant, title, description, onPress, footer }: StepTileProp
 };
 
 const STEP_INDEXES = {
+  StepNotDisplayed: 0,
+
   IdentityVerificationTodo: 1,
   IdentityVerificationPending: 1,
   IdentityVerificationToRedo: 1,
@@ -274,6 +276,7 @@ type Props = {
   canViewAccountDetails: boolean;
   projectName: string;
   refetchAccountAreaQuery: () => void;
+  hasPvidOrQesValidation: boolean;
 };
 
 export const AccountActivationPage = ({
@@ -283,6 +286,7 @@ export const AccountActivationPage = ({
   canViewAccountDetails,
   projectName,
   refetchAccountAreaQuery,
+  hasPvidOrQesValidation,
 }: Props) => {
   const documentsFormRef = useRef<SupportingDocumentsFormRef>(null);
 
@@ -343,9 +347,10 @@ export const AccountActivationPage = ({
         {
           identificationStatus: typeof identificationStatus;
           account: NonNullable<AccountActivationPageQuery["accountMembership"]>["account"];
+          hasPvidOrQesValidation: boolean;
         },
         Step | undefined
-      >({ identificationStatus, account })
+      >({ identificationStatus, account, hasPvidOrQesValidation })
         .with({ identificationStatus: P.nullish }, () => undefined)
         // handle legacy account that didn't go through the new process
         .with(
@@ -381,25 +386,28 @@ export const AccountActivationPage = ({
               .exhaustive();
           }
 
-          if (!hasTransactions) {
+          if (!hasPvidOrQesValidation && !hasTransactions) {
             return canViewAccountDetails && hasIBAN
               ? "AddMoneyToYourNewAccountViaIbanTodo"
               : "AddMoneyToYourNewAccountIbanMissing";
           }
-
+          if (hasPvidOrQesValidation) {
+            return "StepNotDisplayed";
+          }
           return "Done";
         })
         .exhaustive()
     );
   }, [
-    canViewAccountDetails,
-    documentCollectMode,
-    documentCollectionStatus,
-    hasIBAN,
-    hasTransactions,
     identificationStatus,
-    isCompany,
     account,
+    hasPvidOrQesValidation,
+    isCompany,
+    hasTransactions,
+    documentCollectionStatus,
+    documentCollectMode,
+    canViewAccountDetails,
+    hasIBAN,
   ]);
 
   const [contentVisible, setContentVisible] = useBoolean(false);
@@ -631,6 +639,7 @@ export const AccountActivationPage = ({
         </Box>
       </StepScrollView>
     ))
+    .with("StepNotDisplayed", () => <></>)
     .exhaustive();
 
   return (

--- a/clients/banking/src/pages/AccountActivationPage.tsx
+++ b/clients/banking/src/pages/AccountActivationPage.tsx
@@ -276,7 +276,7 @@ type Props = {
   canViewAccountDetails: boolean;
   projectName: string;
   refetchAccountAreaQuery: () => void;
-  hasPvidOrQesValidation: boolean;
+  requireFirstTransfer: boolean;
 };
 
 export const AccountActivationPage = ({
@@ -286,7 +286,7 @@ export const AccountActivationPage = ({
   canViewAccountDetails,
   projectName,
   refetchAccountAreaQuery,
-  hasPvidOrQesValidation,
+  requireFirstTransfer,
 }: Props) => {
   const documentsFormRef = useRef<SupportingDocumentsFormRef>(null);
 
@@ -347,10 +347,10 @@ export const AccountActivationPage = ({
         {
           identificationStatus: typeof identificationStatus;
           account: NonNullable<AccountActivationPageQuery["accountMembership"]>["account"];
-          hasPvidOrQesValidation: boolean;
+          requireFirstTransfer: boolean;
         },
         Step | undefined
-      >({ identificationStatus, account, hasPvidOrQesValidation })
+      >({ identificationStatus, account, requireFirstTransfer })
         .with({ identificationStatus: P.nullish }, () => undefined)
         // handle legacy account that didn't go through the new process
         .with(
@@ -386,12 +386,12 @@ export const AccountActivationPage = ({
               .exhaustive();
           }
 
-          if (!hasPvidOrQesValidation && !hasTransactions) {
+          if (requireFirstTransfer && !hasTransactions) {
             return canViewAccountDetails && hasIBAN
               ? "AddMoneyToYourNewAccountViaIbanTodo"
               : "AddMoneyToYourNewAccountIbanMissing";
           }
-          if (hasPvidOrQesValidation) {
+          if (!requireFirstTransfer) {
             return "StepNotDisplayed";
           }
           return "Done";
@@ -401,7 +401,7 @@ export const AccountActivationPage = ({
   }, [
     identificationStatus,
     account,
-    hasPvidOrQesValidation,
+    requireFirstTransfer,
     isCompany,
     hasTransactions,
     documentCollectionStatus,


### PR DESCRIPTION
Requirement:
- if the user validates his identity with PVID or QES, don't display the tile which ask to iniate a first transfer
- if he validates his identity with Expert, display this tile

I created another step in the account activation: StepNotDisplayed, because if any of the steps was provided it fallbacks to the Done step, which is not the good behaviour. 