### PR TITLE
limit next page placeholder size

### DIFF
--- a/clients/banking/src/components/CardItemTransactionList.tsx
+++ b/clients/banking/src/components/CardItemTransactionList.tsx
@@ -118,7 +118,7 @@ export const CardItemTransactionList = ({
       query: CardTransactionsPageDocument,
       variables: {
         cardId,
-        first: 20,
+        first: NUM_TO_RENDER,
         filters: {
           ...filters,
           status: filters.status ?? DEFAULT_STATUSES,
@@ -181,7 +181,7 @@ export const CardItemTransactionList = ({
             NotAsked: () => null,
             Loading: () => (
               <PlainListViewPlaceholder
-                count={20}
+                count={NUM_TO_RENDER}
                 rowVerticalSpacing={0}
                 headerHeight={48}
                 groupHeaderHeight={48}
@@ -203,7 +203,7 @@ export const CardItemTransactionList = ({
                     onActiveRowChange={onActiveRowChange}
                     loading={{
                       isLoading: nextData.isLoading(),
-                      count: 20,
+                      count: 2,
                     }}
                     onEndReached={() => {
                       if (card?.transactions?.pageInfo.hasNextPage ?? false) {

--- a/clients/banking/src/pages/TransactionListPage.tsx
+++ b/clients/banking/src/pages/TransactionListPage.tsx
@@ -125,7 +125,7 @@ export const TransactionListPage = ({
       query: TransactionListPageDocument,
       variables: {
         accountId,
-        first: 20,
+        first: NUM_TO_RENDER,
         filters: {
           ...filters,
           status: filters.status ?? DEFAULT_STATUSES,
@@ -206,7 +206,7 @@ export const TransactionListPage = ({
             NotAsked: () => null,
             Loading: () => (
               <PlainListViewPlaceholder
-                count={20}
+                count={NUM_TO_RENDER}
                 rowVerticalSpacing={0}
                 groupHeaderHeight={48}
                 headerHeight={48}
@@ -228,7 +228,7 @@ export const TransactionListPage = ({
                     onActiveRowChange={onActiveRowChange}
                     loading={{
                       isLoading: nextData.isLoading(),
-                      count: 20,
+                      count: 2,
                     }}
                     onEndReached={() => {
                       if (data.account?.transactions?.pageInfo.hasNextPage ?? false) {

--- a/clients/banking/src/pages/UpcomingTransactionListPage.tsx
+++ b/clients/banking/src/pages/UpcomingTransactionListPage.tsx
@@ -27,7 +27,7 @@ export const UpcomingTransactionListPage = ({ accountId, canQueryCardOnTransacti
       query: UpcomingTransactionListPageDocument,
       variables: {
         accountId,
-        first: 20,
+        first: NUM_TO_RENDER,
         canQueryCardOnTransaction,
       },
     },
@@ -56,7 +56,7 @@ export const UpcomingTransactionListPage = ({ accountId, canQueryCardOnTransacti
         NotAsked: () => null,
         Loading: () => (
           <PlainListViewPlaceholder
-            count={20}
+            count={NUM_TO_RENDER}
             rowVerticalSpacing={0}
             groupHeaderHeight={48}
             headerHeight={48}
@@ -78,7 +78,7 @@ export const UpcomingTransactionListPage = ({ accountId, canQueryCardOnTransacti
                 onActiveRowChange={onActiveRowChange}
                 loading={{
                   isLoading: nextData.isLoading(),
-                  count: 20,
+                  count: 2,
                 }}
                 onEndReached={() => {
                   if (data.account?.transactions?.pageInfo.hasNextPage ?? false) {


### PR DESCRIPTION
This PR goal is avoid infinite page load in the web-banking.
By reducing placeholder size, when a page is loaded, the user isn't at the end of the list anymore so next page isn't loaded