### PR TITLE
Revamp condition to request identification to display card

### DIFF
--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -767,9 +767,6 @@ export const AccountArea = ({ accountMembershipId }: Props) => {
                                   userStatusIsProcessing={userStatusIsProcessing}
                                   canManageAccountMembership={canManageAccountMembership}
                                   canOrderPhysicalCards={canOrderPhysicalCards}
-                                  B2BMembershipIDVerification={Boolean(
-                                    projectInfo.B2BMembershipIDVerification,
-                                  )}
                                 />
                               ))
                               .with({ name: "AccountMembersArea" }, ({ params }) =>

--- a/clients/banking/src/components/CardItemArea.tsx
+++ b/clients/banking/src/components/CardItemArea.tsx
@@ -43,7 +43,6 @@ type Props = {
   userStatusIsProcessing: boolean;
   canManageAccountMembership: boolean;
   canOrderPhysicalCards: boolean;
-  B2BMembershipIDVerification: boolean;
   large?: boolean;
 };
 
@@ -54,7 +53,6 @@ export const CardItemArea = ({
   refetchAccountAreaQuery,
   canManageAccountMembership,
   canOrderPhysicalCards,
-  B2BMembershipIDVerification,
   large = true,
 }: Props) => {
   // use useResponsive to fit with scroll behavior set in AccountArea
@@ -110,47 +108,7 @@ export const CardItemArea = ({
 
   const isCurrentUserCardOwner = userId === card?.accountMembership.user?.id;
 
-  const cardRequiresIdentityVerification = match({ B2BMembershipIDVerification, card })
-    // Project allows bypassing identity verification for memberships with no rights
-    .with(
-      {
-        B2BMembershipIDVerification: false,
-        card: {
-          accountMembership: {
-            canManageAccountMembership: false,
-            canManageBeneficiaries: false,
-            canViewAccount: false,
-            canInitiatePayments: false,
-            user: { identificationStatus: P.not("ValidIdentity") },
-          },
-        },
-      },
-      () => true,
-    )
-    // In any other case, if recommended level isn't met
-    .with(
-      {
-        card: {
-          accountMembership: P.union(
-            {
-              recommendedIdentificationLevel: "Expert",
-              user: {
-                identificationLevels: { expert: P.not(true) },
-              },
-            },
-            {
-              recommendedIdentificationLevel: "QES",
-              user: {
-                identificationLevels: { QES: P.not(true) },
-              },
-            },
-          ),
-        },
-      },
-      () => true,
-    )
-    // We have a user with a verified identity or settings allow not
-    .otherwise(() => false);
+  const cardRequiresIdentityVerification = card?.accountMembership.statusInfo.status !== "Enabled";
 
   const identificationStatus = card?.accountMembership.user?.identificationStatus ?? undefined;
 

--- a/clients/banking/src/components/CardsArea.tsx
+++ b/clients/banking/src/components/CardsArea.tsx
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  B2BMembershipIDVerification: boolean;
   accountMembership: NonNullable<AccountAreaQuery["accountMembership"]>;
   accountMembershipId: string;
   accountId: string | undefined;
@@ -133,7 +132,6 @@ const useDisplayableCardsInformation = ({
 };
 
 export const CardsArea = ({
-  B2BMembershipIDVerification,
   accountMembership,
   accountMembershipId,
   accountId,
@@ -235,7 +233,6 @@ export const CardsArea = ({
                         userStatusIsProcessing={userStatusIsProcessing}
                         canManageAccountMembership={canManageAccountMembership}
                         canOrderPhysicalCards={canOrderPhysicalCards}
-                        B2BMembershipIDVerification={B2BMembershipIDVerification}
                         large={large}
                       />
                     </>


### PR DESCRIPTION
This PR impacts the card area in the banking app

It changes the condition to request identification by just checking account membership account status.
Finally we don't need to check B2BMembershipIDVerification because when it's `false`, the backend set `statusInfo: Enabled`