### PR TITLE
rollback graphcache version

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -26,7 +26,7 @@
     "@swan-io/chicane": "1.3.4",
     "@swan-io/lake": "2.0.1",
     "@swan-io/shared-business": "2.0.1",
-    "@urql/exchange-graphcache": "6.0.4",
+    "@urql/exchange-graphcache": "6.0.1",
     "core-js": "3.30.2",
     "dayjs": "1.11.7",
     "iban": "0.0.14",

--- a/clients/banking/src/graphql/partner.gql
+++ b/clients/banking/src/graphql/partner.gql
@@ -496,7 +496,6 @@ fragment CardListItem on Card {
   type
   name
   statusInfo {
-    __typename
     status
   }
   spendingLimits {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -26,7 +26,7 @@
     "@swan-io/chicane": "1.3.4",
     "@swan-io/lake": "2.0.1",
     "@swan-io/shared-business": "2.0.1",
-    "@urql/exchange-graphcache": "6.0.4",
+    "@urql/exchange-graphcache": "6.0.1",
     "core-js": "3.30.2",
     "dayjs": "1.11.7",
     "nanoid": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,15 +2494,6 @@
     "@urql/core" ">=4.0.0"
     wonka "^6.3.0"
 
-"@urql/exchange-graphcache@6.0.4":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.4.tgz#55b9dab64369f4a887f10a1a5e5f855ba68283ae"
-  integrity sha512-fzfCUrHzhLycPRa6kYrQYryk0pwmUfeHY9Xqh11A6wtp4/diV7FASlffB5k2j3AWRBxBnqThXDssRXI/G8cACQ==
-  dependencies:
-    "@0no-co/graphql.web" "^1.0.1"
-    "@urql/core" ">=4.0.0"
-    wonka "^6.3.2"
-
 "@urql/introspection@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@urql/introspection/-/introspection-1.0.2.tgz#220769ab8b8a18737a45dda89ee9b5abf37fe0c5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@0no-co/graphql.web@1.0.1", "@0no-co/graphql.web@^1.0.1":
+"@0no-co/graphql.web@1.0.1", "@0no-co/graphql.web@^1.0.0", "@0no-co/graphql.web@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz#db3da0d2cd41548b50f0583c0d2f4743c767e56b"
   integrity sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==
@@ -2484,6 +2484,15 @@
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
     wonka "^6.3.2"
+
+"@urql/exchange-graphcache@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.1.tgz#4bb69ddb03489c3e6ffc09ff13e51d3fd3191b43"
+  integrity sha512-nJCQwem45p1nspbRrZz2oFjyHW6tufT6LQ1SvqE3CN1pLq3v72leZ6nfRMv4RCoh9IxFnv9hr0fn8DQSmQaB4w==
+  dependencies:
+    "@0no-co/graphql.web" "^1.0.0"
+    "@urql/core" ">=4.0.0"
+    wonka "^6.3.0"
 
 "@urql/exchange-graphcache@6.0.4":
   version "6.0.4"
@@ -7670,7 +7679,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-wonka@6.3.2, wonka@^6.3.2:
+wonka@6.3.2, wonka@^6.3.0, wonka@^6.3.2:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.2.tgz#6f32992b332251d7b696b038990f4dc284b3b33d"
   integrity sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==


### PR DESCRIPTION
This PR rollback urql graphcache plugin because previous version fix an issue from graphql codegen

### Explanation
- when we don't add `__typename` in a document query:
  - graphql codegen adds `__typename` in TS types (TS let us use it in our code without error)
  - but graphql codegen didn't add the `__typename` document use to create the request in the runtime
  - but urql graphcache adds `__typename` because it needs it to cache documents

So we had an issue on codegen which was fixed accidently by urql graphcache.

And since `@urql/exchange-graphcache` `v6.0.2` it adds the `__typename` in the http request payload, but removes it before returning the value to the client.

So this is why if we don't set `__typename` it's available in TS but not in client response.

### Solution for the future
We rollback just to have our apps working again but the long term solution is finding a way to fix graphql codegen