### PR TITLE
Display canceled status in transaction list for mobile

### DIFF
--- a/clients/banking/src/components/TransactionListCells.tsx
+++ b/clients/banking/src/components/TransactionListCells.tsx
@@ -265,6 +265,12 @@ export const TransactionSummaryCell = ({ transaction }: { transaction: Transacti
               <Tag color="negative">{t("transactionStatus.rejected")}</Tag>
             </>
           ))
+          .with("CanceledTransactionStatusInfo", () => (
+            <>
+              <Space width={12} />
+              <Tag color="gray">{t("transactionStatus.canceled")}</Tag>
+            </>
+          ))
           .otherwise(() => null)}
       </View>
     </View>


### PR DESCRIPTION
This PR fixes the transaction list for mobile in banking app:  
The `canceled` status was displayed only on large screen. This PR makes `TransactionSummaryCell` (used for mobile) consistent with `TransactionNameCell` (used for desktop)

before:  
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/7b5fd972-7bf4-47a6-a859-3cb95d0e5cfe)

after:  
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/baeac278-08e4-43ec-82fd-182d154eda0c)
