### PR TITLE
Add condition to display warning only if sct payment type

### DIFF
--- a/clients/banking/src/components/TransactionDetail.tsx
+++ b/clients/banking/src/components/TransactionDetail.tsx
@@ -138,7 +138,7 @@ export const TransactionDetail = ({ transaction, large }: Props) => {
         <Tile
           style={styles.tile}
           footer={match(transaction)
-            .with({ originTransactionId: P.string }, () => (
+            .with({ type: "SepaCreditTransferOut" }, { originTransactionId: P.string }, () => (
               // TODO: switch this condition with the next one to display the warning message as soon as the back had fixed its issue
               <LakeAlert
                 anchored={true}


### PR DESCRIPTION
I updated the condition to display the warning message fallback in a transaction detail.
It's visible only if the payment type is  `SepaCreditTransferOut`.

![image](https://github.com/swan-io/swan-partner-frontend/assets/58843948/3e8bc2ee-14c7-4902-9b75-d5fd045e9ccc)

PAY-4889