### PR TITLE
fix card name for new physical card

### DIFF
--- a/clients/banking/src/components/CardWizard.tsx
+++ b/clients/banking/src/components/CardWizard.tsx
@@ -641,6 +641,7 @@ export const CardWizard = ({
                             if (memberships.length === 1) {
                               setStep({
                                 name: "CardProductIndividualDelivery",
+                                cardName,
                                 cardProduct,
                                 cardFormat,
                                 memberships,
@@ -653,6 +654,7 @@ export const CardWizard = ({
                             } else {
                               setStep({
                                 name: "CardProductDelivery",
+                                cardName,
                                 cardProduct,
                                 cardFormat,
                                 memberships,
@@ -710,6 +712,7 @@ export const CardWizard = ({
                 .with(
                   { name: "CardProductDelivery" },
                   ({
+                    cardName,
                     cardProduct,
                     cardFormat,
                     memberships,
@@ -725,6 +728,7 @@ export const CardWizard = ({
                         if (mode === "Grouped") {
                           setStep({
                             name: "CardProductGroupedDelivery",
+                            cardName,
                             cardProduct,
                             cardFormat,
                             memberships,
@@ -737,6 +741,7 @@ export const CardWizard = ({
                         } else {
                           setStep({
                             name: "CardProductIndividualDelivery",
+                            cardName,
                             cardProduct,
                             cardFormat,
                             memberships,


### PR DESCRIPTION
This PR fix card name in card wizard.  
The issue comes from missing forwarded field between steps. So to fix this I just added `cardName` in `setStep`. But I think we can improve the data model of this page by removing optional fields in step type.  
But as the flow is a little complex I didn't touch it at the moment to avoid breaking things and focus on fixing the bug as fast as I can.