### PR TITLE
remove exhaustive check for transactions

### DIFF
--- a/clients/banking/src/components/TransactionListCells.tsx
+++ b/clients/banking/src/components/TransactionListCells.tsx
@@ -130,21 +130,16 @@ export const TransactionNameCell = ({ transaction }: { transaction: Transaction 
   );
 };
 
-const toSeparateWords = (value: string) => {
+export const formatTransactionType = (typename: string) => {
+  const unprefixed = typename.startsWith("SEPA") ? typename.slice(4) : typename;
+
   return (
-    value.charAt(0).toUpperCase() +
-    value
+    unprefixed.charAt(0).toUpperCase() +
+    unprefixed
       .slice(1)
       .replace(/([A-Z])/g, " $1")
       .toLowerCase()
   );
-};
-
-export const formatTransactionType = (typename: string) => {
-  if (typename.startsWith("SEPA")) {
-    return toSeparateWords(typename.slice(4));
-  }
-  return toSeparateWords(typename);
 };
 
 export const TransactionMethodCell = ({

--- a/clients/banking/src/components/TransactionListCells.tsx
+++ b/clients/banking/src/components/TransactionListCells.tsx
@@ -130,7 +130,28 @@ export const TransactionNameCell = ({ transaction }: { transaction: Transaction 
   );
 };
 
-export const TransactionMethodCell = ({ transaction }: { transaction: Transaction }) => {
+const toSeparateWords = (value: string) => {
+  return (
+    value.charAt(0).toUpperCase() +
+    value
+      .slice(1)
+      .replace(/([A-Z])/g, " $1")
+      .toLowerCase()
+  );
+};
+
+export const formatTransactionType = (typename: string) => {
+  if (typename.startsWith("SEPA")) {
+    return toSeparateWords(typename.slice(4));
+  }
+  return toSeparateWords(typename);
+};
+
+export const TransactionMethodCell = ({
+  transaction,
+}: {
+  transaction: Transaction | { __typename: string };
+}) => {
   return (
     <View style={[styles.cell, styles.cellRightAlign]}>
       <LakeText align="right" variant="smallMedium" color={colors.gray[600]}>
@@ -152,7 +173,7 @@ export const TransactionMethodCell = ({ transaction }: { transaction: Transactio
             { __typename: "SEPADirectDebitTransaction" },
             () => t("transactions.method.DirectDebit"),
           )
-          .exhaustive()}
+          .otherwise(({ __typename }) => formatTransactionType(__typename))}
       </LakeText>
     </View>
   );


### PR DESCRIPTION
This PR removes exhaustive check for transactions to let payment team creates new transaction types without breaking banking app