### PR TITLE
Fix card access without b2b

### DIFF
--- a/clients/banking/src/components/CardItemArea.tsx
+++ b/clients/banking/src/components/CardItemArea.tsx
@@ -110,7 +110,8 @@ export const CardItemArea = ({
 
   const isCurrentUserCardOwner = userId === card?.accountMembership.user?.id;
 
-  const cardRequiresIdentityVerification = card?.accountMembership.statusInfo.status !== "Enabled";
+  const cardRequiresIdentityVerification =
+    B2BMembershipIDVerification === true && card?.accountMembership.statusInfo.status !== "Enabled";
 
   const bindingUserError = card?.accountMembership.statusInfo.status === "BindingUserError";
 


### PR DESCRIPTION
Previously we changed `cardRequiresIdentityVerification` because we thought that when `B2BMembershipIDVerification === false`, user status was always `Enabled` but this isn't the case.  
So unverified users can't see their cards even if `cardRequiresIdentityVerification === false`.  
The goal of this PR is giving back card access to unverified users if `B2BMembershipIDVerification === false`