### PR TITLE
Remove condition to display alert for virtual and physical card

### DIFF
--- a/clients/banking/src/components/CardItemArea.tsx
+++ b/clients/banking/src/components/CardItemArea.tsx
@@ -115,11 +115,6 @@ export const CardItemArea = ({
 
   const bindingUserError = card?.accountMembership.statusInfo.status === "BindingUserError";
 
-  const statusCardInProgress =
-    card?.physicalCard?.statusInfo.status === "Processing" ||
-    card?.physicalCard?.statusInfo.status === "Renewed" ||
-    card?.physicalCard?.statusInfo.status === "ToActivate";
-
   const identificationStatus = card?.accountMembership.user?.identificationStatus ?? undefined;
 
   if (card == null) {
@@ -197,7 +192,7 @@ export const CardItemArea = ({
               style={styles.container}
               contentContainerStyle={[styles.contents, large && styles.contentsLarge]}
             >
-              {bindingUserError && B2BMembershipIDVerification === true && statusCardInProgress && (
+              {bindingUserError && B2BMembershipIDVerification === true && (
                 <>
                   <Space height={24} />
 


### PR DESCRIPTION
If the membership status is in binding user error, the we display an alert. 
I removed the last condition "status card: processing" because this alert should be displayed for all type of cards, not only for the physical ones. 