### PR TITLE
add validation on first name and last name for new membership form

### DIFF
--- a/clients/banking/src/components/NewMembershipWizard.tsx
+++ b/clients/banking/src/components/NewMembershipWizard.tsx
@@ -32,6 +32,7 @@ import {
   validateAddressLine,
   validateBirthdate,
   validateEmail,
+  validateName,
   validateRequired,
 } from "../utils/validations";
 
@@ -159,13 +160,13 @@ export const NewMembershipWizard = ({
     firstName: {
       initialValue: partiallySavedValues?.firstName ?? "",
       strategy: "onBlur",
-      validate: validateRequired,
+      validate: combineValidators(validateRequired, validateName),
       sanitize: value => value.trim(),
     },
     lastName: {
       initialValue: partiallySavedValues?.lastName ?? "",
       strategy: "onBlur",
-      validate: validateRequired,
+      validate: combineValidators(validateRequired, validateName),
       sanitize: value => value.trim(),
     },
     birthDate: {

--- a/clients/banking/src/locales/de.json
+++ b/clients/banking/src/locales/de.json
@@ -237,6 +237,7 @@
   "common.form.invalidAmount": "Dieser Betrag ist ungültig",
   "common.form.invalidDate": "Dieses Datum ist ungültig",
   "common.form.invalidEmail": "Diese E-Mail-Adresse ist ungültig",
+  "common.form.invalidName": "Ungültiger Name",
   "common.form.invalidPhoneNumber": "Diese Telefonnummer ist ungültig",
   "common.form.invalidTaxIdentificationNumber": "Diese Steuer-Identifikationsnummer ist ungültig",
   "common.form.invalidTime": "Diese Uhrzeit ist ungültig",

--- a/clients/banking/src/locales/en.json
+++ b/clients/banking/src/locales/en.json
@@ -237,6 +237,7 @@
   "common.form.invalidAmount": "Invalid amount",
   "common.form.invalidDate": "Invalid date",
   "common.form.invalidEmail": "Invalid email",
+  "common.form.invalidName": "Invalid name",
   "common.form.invalidPhoneNumber": "Invalid phone number",
   "common.form.invalidTaxIdentificationNumber": "Invalid tax identification number",
   "common.form.invalidTime": "Invalid time",

--- a/clients/banking/src/locales/es.json
+++ b/clients/banking/src/locales/es.json
@@ -237,6 +237,7 @@
   "common.form.invalidAmount": "La cantidad no es válida",
   "common.form.invalidDate": "Esta fecha no es válida",
   "common.form.invalidEmail": "Este correo electrónico no es válido",
+  "common.form.invalidName": "Nombre inválido",
   "common.form.invalidPhoneNumber": "Este número de teléfono no es válido",
   "common.form.invalidTaxIdentificationNumber": "Este número de identificación fiscal no es válido",
   "common.form.invalidTime": "Esta hora es inválida",

--- a/clients/banking/src/locales/fr.json
+++ b/clients/banking/src/locales/fr.json
@@ -237,6 +237,7 @@
   "common.form.invalidAmount": "Ce montant n'est pas valide",
   "common.form.invalidDate": "Cette date est invalide",
   "common.form.invalidEmail": "Cet email est invalide",
+  "common.form.invalidName": "Nom invalide",
   "common.form.invalidPhoneNumber": "Ce numéro de téléphone est invalide",
   "common.form.invalidTaxIdentificationNumber": "Ce numéro d'identification fiscale n'est pas valide",
   "common.form.invalidTime": "Cette heure est invalide",

--- a/clients/banking/src/locales/it.json
+++ b/clients/banking/src/locales/it.json
@@ -237,6 +237,7 @@
   "common.form.invalidAmount": "Questo importo non è valido",
   "common.form.invalidDate": "Questa data non è valida",
   "common.form.invalidEmail": "Questo indirizzo e-mail non è valido",
+  "common.form.invalidName": "Nome non valido",
   "common.form.invalidPhoneNumber": "Questo numero di telefono non è valido",
   "common.form.invalidTaxIdentificationNumber": "Questo numero di identificazione fiscale non è valido",
   "common.form.invalidTime": "Questa ora non è valida",

--- a/clients/banking/src/locales/pt.json
+++ b/clients/banking/src/locales/pt.json
@@ -237,6 +237,7 @@
   "common.form.invalidAmount": "Este valor é inválido",
   "common.form.invalidDate": "Esta data é inválida",
   "common.form.invalidEmail": "Este e-mail é inválido",
+  "common.form.invalidName": "Nome inválido",
   "common.form.invalidPhoneNumber": "Este número de telemóvel é inválido",
   "common.form.invalidTaxIdentificationNumber": "Número de identificação fiscal inválido",
   "common.form.invalidTime": "Este horário é inválido",

--- a/clients/banking/src/utils/validations.ts
+++ b/clients/banking/src/utils/validations.ts
@@ -1,4 +1,5 @@
 import { Lazy } from "@swan-io/boxed";
+import { deburr } from "@swan-io/lake/src/utils/string";
 import { isValidVatNumber } from "@swan-io/shared-business/src/utils/validation";
 import dayjs from "dayjs";
 import { Validator } from "react-ux-form";
@@ -13,6 +14,21 @@ export const validateNullableRequired: Validator<string | undefined> = value => 
 export const validateRequired: Validator<string> = value => {
   if (!value) {
     return t("common.form.required");
+  }
+};
+
+export const validateName: Validator<string> = value => {
+  if (!value) {
+    return;
+  }
+
+  const name = deburr(value);
+
+  // Accepts only letters, spaces and dashes
+  const isValid = name.match(/^[a-zA-Z\s-]*$/);
+
+  if (!isValid) {
+    return t("common.form.invalidName");
   }
 };
 


### PR DESCRIPTION
In banking app => new membership form, there wasn't validation on first name and last name.  
So if we set invalid names we had server error instead of an error displayed below the field.  

This PR solve this by adding front-end validation on first name and last name which accepts:
- all letters `A-Za-z`
- spaces `\s`
- dashes for composed names `-`
- letters with accents (works thanks to deburr function)

![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/4704c8a4-7a1c-483f-b171-68fe1e79ea3d)
