### PR TITLE
remove exhaustive check for fees type

### DIFF
--- a/clients/banking/src/components/TransactionDetail.tsx
+++ b/clients/banking/src/components/TransactionDetail.tsx
@@ -11,6 +11,7 @@ import { Tile } from "@swan-io/lake/src/components/Tile";
 import { commonStyles } from "@swan-io/lake/src/constants/commonStyles";
 import { colors } from "@swan-io/lake/src/constants/design";
 import {
+  isEmpty,
   isNotNullish,
   isNotNullishOrEmpty,
   isNullishOrEmpty,
@@ -142,9 +143,14 @@ export const TransactionDetail = ({ transaction, large }: Props) => {
           style={styles.tile}
           footer={match(transaction)
             // BankingFee should never happen, so we don't handle it
-            .with({ feesType: P.not("BankingFee") }, ({ feesType }) => (
-              <LakeAlert anchored={true} variant="info" title={getFeesDescription(feesType)} />
-            ))
+            .with({ feesType: P.not("BankingFee") }, ({ feesType }) => {
+              const description = getFeesDescription(feesType); // can be empty if a new fees type is added and not handled
+              if (isEmpty(description)) {
+                return null;
+              }
+
+              return <LakeAlert anchored={true} variant="info" title={description} />;
+            })
             .with(
               {
                 type: P.union("SepaCreditTransferOut", "SepaCreditTransferIn"),

--- a/clients/banking/src/components/TransactionDetail.tsx
+++ b/clients/banking/src/components/TransactionDetail.tsx
@@ -11,9 +11,9 @@ import { Tile } from "@swan-io/lake/src/components/Tile";
 import { commonStyles } from "@swan-io/lake/src/constants/commonStyles";
 import { colors } from "@swan-io/lake/src/constants/design";
 import {
-  isEmpty,
   isNotNullish,
   isNotNullishOrEmpty,
+  isNullish,
   isNullishOrEmpty,
 } from "@swan-io/lake/src/utils/nullish";
 import { countries } from "@swan-io/shared-business/src/constants/countries";
@@ -145,7 +145,7 @@ export const TransactionDetail = ({ transaction, large }: Props) => {
             // BankingFee should never happen, so we don't handle it
             .with({ feesType: P.not("BankingFee") }, ({ feesType }) => {
               const description = getFeesDescription(feesType); // can be empty if a new fees type is added and not handled
-              if (isEmpty(description)) {
+              if (isNullish(description)) {
                 return null;
               }
 

--- a/clients/banking/src/utils/templateTranslations.ts
+++ b/clients/banking/src/utils/templateTranslations.ts
@@ -163,4 +163,4 @@ export const getFeesDescription = (fees: Exclude<FeesTypeEnum, "BankingFee">) =>
       t("transaction.fees.description.processingJudicialOrAdministrativeSeizure"),
     )
     .with("UnauthorizedOverdraft", () => t("transaction.fees.description.unauthorizedOverdraft"))
-    .otherwise(() => "");
+    .otherwise(() => undefined);

--- a/clients/banking/src/utils/templateTranslations.ts
+++ b/clients/banking/src/utils/templateTranslations.ts
@@ -163,4 +163,4 @@ export const getFeesDescription = (fees: Exclude<FeesTypeEnum, "BankingFee">) =>
       t("transaction.fees.description.processingJudicialOrAdministrativeSeizure"),
     )
     .with("UnauthorizedOverdraft", () => t("transaction.fees.description.unauthorizedOverdraft"))
-    .exhaustive();
+    .otherwise(() => "");


### PR DESCRIPTION
Payment team planned to add new fees type.  
Even if we're aware about this and plan to update our front-end client to handle them with proper messages, I prefer remove exhaustive check to avoid constraints for deployment date.  
Without this PR we have to take care front-end is deployed just after payment to avoid crashes.  
