### PR TITLE
Unwrap GraphQLError

### DIFF
--- a/clients/banking/src/utils/logger.ts
+++ b/clients/banking/src/utils/logger.ts
@@ -66,16 +66,18 @@ export const logBackendError = (
   const requestId = headers["x-request-id"];
   const hasMultipleErrors = graphQLErrors.length > 1;
 
-  graphQLErrors.forEach(error => {
+  graphQLErrors.forEach(graphQLError => {
     if (
       hasMultipleErrors &&
-      error.message.startsWith("Cannot return null for non-nullable field")
+      graphQLError.message.startsWith("Cannot return null for non-nullable field")
     ) {
       return;
     }
 
+    const error = graphQLError.originalError ?? graphQLError;
+
+    // Mutate the error message to prepend the requestId
     if (isNotNullish(requestId)) {
-      // Mutate the error message to prepend the requestId
       error.message = `${requestId} - ${error.message}`;
     }
 
@@ -89,7 +91,7 @@ export const logBackendError = (
         query: printQuery(query),
         requestPolicy: context.requestPolicy,
         suspense: context.suspense,
-        variables, // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+        variables,
       },
     });
   });

--- a/clients/banking/src/utils/logger.ts
+++ b/clients/banking/src/utils/logger.ts
@@ -66,20 +66,14 @@ export const logBackendError = (
   const requestId = headers["x-request-id"];
   const hasMultipleErrors = graphQLErrors.length > 1;
 
-  graphQLErrors.forEach(graphQLError => {
-    if (
-      hasMultipleErrors &&
-      graphQLError.message.startsWith("Cannot return null for non-nullable field")
-    ) {
+  graphQLErrors.forEach(({ message }) => {
+    if (hasMultipleErrors && message.startsWith("Cannot return null for non-nullable field")) {
       return;
     }
 
-    const error = graphQLError.originalError ?? graphQLError;
-
-    // Mutate the error message to prepend the requestId
-    if (isNotNullish(requestId)) {
-      error.message = `${requestId} - ${error.message}`;
-    }
+    // Update the error message to prepend the requestId
+    const error = new Error(isNotNullish(requestId) ? `${requestId} - ${message}` : message);
+    error.name = "GraphQLError";
 
     captureException(error, {
       tags: {

--- a/clients/onboarding/src/utils/logger.ts
+++ b/clients/onboarding/src/utils/logger.ts
@@ -64,20 +64,14 @@ export const logBackendError = (
   const requestId = headers["x-request-id"];
   const hasMultipleErrors = graphQLErrors.length > 1;
 
-  graphQLErrors.forEach(graphQLError => {
-    if (
-      hasMultipleErrors &&
-      graphQLError.message.startsWith("Cannot return null for non-nullable field")
-    ) {
+  graphQLErrors.forEach(({ message }) => {
+    if (hasMultipleErrors && message.startsWith("Cannot return null for non-nullable field")) {
       return;
     }
 
-    const error = graphQLError.originalError ?? graphQLError;
-
-    // Mutate the error message to prepend the requestId
-    if (isNotNullish(requestId)) {
-      error.message = `${requestId} - ${error.message}`;
-    }
+    // Update the error message to prepend the requestId
+    const error = new Error(isNotNullish(requestId) ? `${requestId} - ${message}` : message);
+    error.name = "GraphQLError";
 
     captureException(error, {
       tags: {

--- a/clients/onboarding/src/utils/logger.ts
+++ b/clients/onboarding/src/utils/logger.ts
@@ -64,16 +64,18 @@ export const logBackendError = (
   const requestId = headers["x-request-id"];
   const hasMultipleErrors = graphQLErrors.length > 1;
 
-  graphQLErrors.forEach(error => {
+  graphQLErrors.forEach(graphQLError => {
     if (
       hasMultipleErrors &&
-      error.message.startsWith("Cannot return null for non-nullable field")
+      graphQLError.message.startsWith("Cannot return null for non-nullable field")
     ) {
       return;
     }
 
+    const error = graphQLError.originalError ?? graphQLError;
+
+    // Mutate the error message to prepend the requestId
     if (isNotNullish(requestId)) {
-      // Mutate the error message to prepend the requestId
       error.message = `${requestId} - ${error.message}`;
     }
 
@@ -87,7 +89,7 @@ export const logBackendError = (
         query: printQuery(query),
         requestPolicy: context.requestPolicy,
         suspense: context.suspense,
-        variables, // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+        variables,
       },
     });
   });


### PR DESCRIPTION
Lately, `GraphQLError` instances has been updated to something that doesn't seems to inherit from `Error`. As we don't really care about other error properties (we already have `extra`), we enforce it.

<img width="467" alt="Screenshot 2023-06-09 at 15 42 00" src="https://github.com/swan-io/swan-partner-frontend/assets/1902323/5e89435a-cc36-4d68-a11e-19749d7e9c7a">
