### PR TITLE
update validation rule for names

### DIFF
--- a/clients/banking/src/components/MembershipDetailEditor.tsx
+++ b/clients/banking/src/components/MembershipDetailEditor.tsx
@@ -28,6 +28,7 @@ import { Router } from "../utils/routes";
 import {
   validateAddressLine,
   validateBirthdate,
+  validateName,
   validateRequired,
   validateTaxIdentificationNumber,
 } from "../utils/validations";
@@ -107,7 +108,7 @@ export const MembershipDetailEditor = ({
         )
         .with({ user: { lastName: P.string } }, ({ user }) => user.lastName)
         .otherwise(() => ""),
-      validate: validateRequired,
+      validate: combineValidators(validateRequired, validateName),
     },
     firstName: {
       initialValue: match(editingAccountMembership)
@@ -124,7 +125,7 @@ export const MembershipDetailEditor = ({
         )
         .with({ user: { firstName: P.string } }, ({ user }) => user.firstName)
         .otherwise(() => ""),
-      validate: validateRequired,
+      validate: combineValidators(validateRequired, validateName),
     },
     birthDate: {
       initialValue: match(editingAccountMembership)

--- a/clients/banking/src/utils/validations.ts
+++ b/clients/banking/src/utils/validations.ts
@@ -1,5 +1,4 @@
 import { Lazy } from "@swan-io/boxed";
-import { deburr } from "@swan-io/lake/src/utils/string";
 import { isValidVatNumber } from "@swan-io/shared-business/src/utils/validation";
 import dayjs from "dayjs";
 import { Validator } from "react-ux-form";
@@ -22,10 +21,16 @@ export const validateName: Validator<string> = value => {
     return;
   }
 
-  const name = deburr(value);
+  // Rule copied from the backend
+  if (value.length > 100) {
+    return t("common.form.invalidName");
+  }
 
-  // Accepts only letters, spaces and dashes
-  const isValid = name.match(/^[a-zA-Z\s-]*$/);
+  // This regex was copied from the backend to ensure that the validation is the same
+  // Matches all unicode letters, spaces, dashes, apostrophes, commas, and single quotes
+  const isValid = value.match(
+    /^(?:[A-Za-zÀ-ÖÙ-öù-ƿǄ-ʯʹ-ʽΈ-ΊΎ-ΡΣ-ҁҊ-Ֆա-ևႠ-Ⴥა-ჺᄀ-፜፩-ᎏᵫ-ᶚḀ-῾ⴀ-ⴥ⺀-⿕ぁ-ゖゝ-ㇿ㋿-鿯鿿-ꒌꙀ-ꙮꚀ-ꚙꜦ-ꞇꞍ-ꞿꥠ-ꥼＡ-Ｚａ-ｚ]| |'|-|Ά|Ό|,)*$/,
+  );
 
   if (!isValid) {
     return t("common.form.invalidName");


### PR DESCRIPTION
In banking app => new membership modal: validation rules for `firstName` and `lastName` was too restrictive.  
This PR brings exactly same validation rules as backend app to solve this.  

This PR also update put the same validation rules in membership edition.  
