### PR TITLE
fix conditions in cards on binding user error

### DIFF
--- a/clients/banking/src/components/CardItemArea.tsx
+++ b/clients/banking/src/components/CardItemArea.tsx
@@ -110,10 +110,19 @@ export const CardItemArea = ({
 
   const isCurrentUserCardOwner = userId === card?.accountMembership.user?.id;
 
-  const cardRequiresIdentityVerification =
-    B2BMembershipIDVerification === true && card?.accountMembership.statusInfo.status !== "Enabled";
+  const membershipStatus = card?.accountMembership.statusInfo;
 
-  const bindingUserError = card?.accountMembership.statusInfo.status === "BindingUserError";
+  const cardRequiresIdentityVerification =
+    B2BMembershipIDVerification === true &&
+    membershipStatus?.__typename === "AccountMembershipBindingUserErrorStatusInfo" &&
+    membershipStatus.idVerifiedMatchError;
+
+  const bindingUserError =
+    membershipStatus?.__typename === "AccountMembershipBindingUserErrorStatusInfo" &&
+    (membershipStatus.birthDateMatchError ||
+      membershipStatus.firstNameMatchError ||
+      membershipStatus.lastNameMatchError ||
+      membershipStatus.phoneNumberMatchError);
 
   const identificationStatus = card?.accountMembership.user?.identificationStatus ?? undefined;
 

--- a/clients/banking/src/graphql/partner.gql
+++ b/clients/banking/src/graphql/partner.gql
@@ -666,6 +666,11 @@ query CardPage($cardId: ID!) {
         __typename
         status
         ... on AccountMembershipBindingUserErrorStatusInfo {
+          idVerifiedMatchError
+          firstNameMatchError
+          lastNameMatchError
+          phoneNumberMatchError
+          birthDateMatchError
           restrictedTo {
             firstName
             lastName


### PR DESCRIPTION
In `CardItemArea` we display some specific UI when member is in binding user error status.  
But he can be in this status for 2 different reasons:
- 1️⃣ if he didn't verified his identity, we should display a button `Verify my identity`
- 2️⃣ if informations mismatch between invitation information and informations used for verification, we should display an alert about information conflicts

All UI was already done but we always display both states. The goal of this PR is just making distinct conditions for those 2 use cases.  

Screenshot for 1️⃣ 
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/ad098381-8383-4859-bf0b-ccc1efdeb467)

Screenshot for 2️⃣ 
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/7170ce25-ebae-46ba-a30a-764d5a3bf191)
