### PR TITLE
fix scroll in card wizard

### DIFF
--- a/clients/banking/src/components/CardWizard.tsx
+++ b/clients/banking/src/components/CardWizard.tsx
@@ -152,7 +152,6 @@ const styles = StyleSheet.create({
   },
   contentsContents: {
     flexGrow: 1,
-    flexShrink: 1,
     justifyContent: "center",
     paddingHorizontal: spacings[96],
     paddingVertical: spacings[24],
@@ -161,7 +160,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacings[24],
     paddingVertical: spacings[24],
     flexGrow: 1,
-    flexShrink: 1,
   },
   mobileZonePadding: {
     paddingHorizontal: spacings[24],

--- a/clients/banking/src/components/CardWizard.tsx
+++ b/clients/banking/src/components/CardWizard.tsx
@@ -152,6 +152,7 @@ const styles = StyleSheet.create({
   },
   contentsContents: {
     flexGrow: 1,
+    flexShrink: 1,
     justifyContent: "center",
     paddingHorizontal: spacings[96],
     paddingVertical: spacings[24],
@@ -160,6 +161,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacings[24],
     paddingVertical: spacings[24],
     flexGrow: 1,
+    flexShrink: 1,
   },
   mobileZonePadding: {
     paddingHorizontal: spacings[24],

--- a/clients/banking/src/components/CardWizardMembers.tsx
+++ b/clients/banking/src/components/CardWizardMembers.tsx
@@ -56,12 +56,6 @@ const styles = StyleSheet.create({
     backgroundColor: backgroundColor.default,
     zIndex: 1,
   },
-  itemSmall: {
-    paddingVertical: spacings[12],
-    borderBottomColor: colors.gray[100],
-    borderBottomWidth: 1,
-    paddingHorizontal: spacings[24],
-  },
 });
 
 export type Member = AccountMembershipFragment;
@@ -174,6 +168,7 @@ export const CardWizardMembers = forwardRef<CardWizardMembersRef, Props>(
                     </Tag>
                   </View>
                 );
+
                 return (
                   <Pressable
                     key={node.id}
@@ -186,15 +181,11 @@ export const CardWizardMembers = forwardRef<CardWizardMembersRef, Props>(
                       )
                     }
                   >
-                    {({ hovered }) =>
-                      large ? (
-                        <Tile hovered={hovered} selected={isSelected} paddingVertical={16}>
-                          {contents}
-                        </Tile>
-                      ) : (
-                        <View style={styles.itemSmall}>{contents}</View>
-                      )
-                    }
+                    {({ hovered }) => (
+                      <Tile hovered={hovered} selected={isSelected} paddingVertical={16}>
+                        {contents}
+                      </Tile>
+                    )}
                   </Pressable>
                 );
               })}

--- a/clients/banking/src/components/CardWizardMembers.tsx
+++ b/clients/banking/src/components/CardWizardMembers.tsx
@@ -10,26 +10,18 @@ import { Space } from "@swan-io/lake/src/components/Space";
 import { Tag } from "@swan-io/lake/src/components/Tag";
 import { Tile } from "@swan-io/lake/src/components/Tile";
 import { commonStyles } from "@swan-io/lake/src/constants/commonStyles";
-import {
-  backgroundColor,
-  breakpoints,
-  colors,
-  negativeSpacings,
-  spacings,
-} from "@swan-io/lake/src/constants/design";
+import { backgroundColor, breakpoints, colors, spacings } from "@swan-io/lake/src/constants/design";
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useState } from "react";
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   ScrollView,
+  StyleProp,
   StyleSheet,
   View,
+  ViewStyle,
 } from "react-native";
-import {
-  AccountMembershipFragment,
-  GetCardProductsQuery,
-  GetEligibleCardMembershipsQuery,
-} from "../graphql/partner";
+import { AccountMembershipFragment, GetEligibleCardMembershipsQuery } from "../graphql/partner";
 import { getMemberName } from "../utils/accountMembership";
 import { t } from "../utils/i18n";
 import { ErrorView } from "./ErrorView";
@@ -37,20 +29,6 @@ import { ErrorView } from "./ErrorView";
 const styles = StyleSheet.create({
   root: {
     ...commonStyles.fill,
-  },
-  container: {
-    ...commonStyles.fill,
-    paddingHorizontal: spacings[4],
-  },
-  containerSmall: {
-    ...commonStyles.fill,
-    marginHorizontal: negativeSpacings[24],
-    paddingHorizontal: 0,
-  },
-  contents: {
-    flexGrow: 1,
-    alignItems: "stretch",
-    justifyContent: "center",
   },
   lineContainer: {
     flexDirection: "row",
@@ -86,15 +64,13 @@ const styles = StyleSheet.create({
   },
 });
 
-type CardProduct = NonNullable<GetCardProductsQuery["projectInfo"]["cardProducts"]>[number];
-
 export type Member = AccountMembershipFragment;
 
 type Props = {
-  cardProduct: CardProduct;
-  accountId: string;
   initialMemberships?: Member[];
   account: GetEligibleCardMembershipsQuery["account"];
+  style?: StyleProp<ViewStyle>;
+  contentContainerStyle?: StyleProp<ViewStyle>;
   onSubmit: (currentMembers: Member[]) => void;
   setAfter: (cursor: string) => void;
 };
@@ -102,7 +78,10 @@ type Props = {
 export type CardWizardMembersRef = { submit: () => void };
 
 export const CardWizardMembers = forwardRef<CardWizardMembersRef, Props>(
-  ({ initialMemberships, account, onSubmit, setAfter }: Props, ref) => {
+  (
+    { initialMemberships, account, style, contentContainerStyle, onSubmit, setAfter }: Props,
+    ref,
+  ) => {
     const [currentMembers, setCurrentMembers] = useState<Member[]>(() => initialMemberships ?? []);
 
     useImperativeHandle(
@@ -151,8 +130,8 @@ export const CardWizardMembers = forwardRef<CardWizardMembersRef, Props>(
       <ResponsiveContainer style={styles.root} breakpoint={breakpoints.medium}>
         {({ large }) => (
           <ScrollView
-            style={large ? styles.container : styles.containerSmall}
-            contentContainerStyle={styles.contents}
+            style={style}
+            contentContainerStyle={contentContainerStyle}
             onScroll={onScroll}
             scrollEventThrottle={16}
           >


### PR DESCRIPTION
In card wizard, if the screen is too small, we can't scroll to the top.  
I don't know why we did have a css rule reducing the height of the form.  
I removed it and tested on desktop on mobile and everything works well.

Here is a screen of the issue solved:  
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/17f16ace-fc67-4385-9b2f-b93e91676012)
