### PR TITLE
Add tax info alert

### DIFF
--- a/clients/onboarding/src/locales/de.json
+++ b/clients/onboarding/src/locales/de.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/en/articles/5000716-what-are-ultimate-beneficial-owners-where-do-i-find-my-company-s-ubos",
   "supportingDocument.noFilename": "Ohne Titel",
+  "taxIdentificationNumber.germanInfo": "Wenn die Steuer-ID während der Registrierung nicht angegeben wird, wird sie per E-Mail angefordert. Wenn sie nicht innerhalb von 90 Tagen bereitgestellt wird, wird das Konto gesperrt.",
   "wizard.back": "Zurück",
   "wizard.finalize": "Abschließen",
   "wizard.next": "Weiter"

--- a/clients/onboarding/src/locales/en.json
+++ b/clients/onboarding/src/locales/en.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/en/articles/5000716-what-are-ultimate-beneficial-owners-where-do-i-find-my-company-s-ubos",
   "supportingDocument.noFilename": "Untitled",
+  "taxIdentificationNumber.germanInfo": "If the tax id is not provided during the onboarding, it will be requested by email. If not provided within 90 days we'll suspend the account",
   "wizard.back": "Previous",
   "wizard.finalize": "Finalize",
   "wizard.next": "Next"

--- a/clients/onboarding/src/locales/es.json
+++ b/clients/onboarding/src/locales/es.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/en/articles/5000716-what-are-ultimate-beneficial-owners-where-do-i-find-my-company-s-ubos",
   "supportingDocument.noFilename": "Sin título",
+  "taxIdentificationNumber.germanInfo": "Si no se proporciona el número de identificación fiscal durante el registro, se solicitará por correo electrónico. Si no se proporciona en un plazo de 90 días, suspenderemos la cuenta.",
   "wizard.back": "Anterior",
   "wizard.finalize": "Finalizar",
   "wizard.next": "Siguiente"

--- a/clients/onboarding/src/locales/fr.json
+++ b/clients/onboarding/src/locales/fr.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/fr/articles/5000716-qui-sont-les-beneficiaires-effectifs-de-mon-entreprise",
   "supportingDocument.noFilename": "Sans titre",
+  "taxIdentificationNumber.germanInfo": "Si l'identifiant fiscal n'est pas fourni lors de l'intégration, il sera demandé par e-mail. Si l'identifiant n'est pas fourni dans les 90 jours, nous suspendrons le compte.",
   "wizard.back": "Précédent",
   "wizard.finalize": "Finalisez",
   "wizard.next": "Suivant"

--- a/clients/onboarding/src/locales/it.json
+++ b/clients/onboarding/src/locales/it.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/en/articles/5000716-what-are-ultimate-beneficial-owners-where-do-i-find-my-company-s-ubos",
   "supportingDocument.noFilename": "Senza titolo",
+  "taxIdentificationNumber.germanInfo": "Se l'identificativo fiscale non viene fornito durante la registrazione, verrà richiesto via email. Se non fornito entro 90 giorni, sospendiamo l'account",
   "wizard.back": "Indietro",
   "wizard.finalize": "Finalizza",
   "wizard.next": "Avanti"

--- a/clients/onboarding/src/locales/nl.json
+++ b/clients/onboarding/src/locales/nl.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/en/articles/5000716-what-are-ultimate-beneficial-owners-where-do-i-find-my-company-s-ubos",
   "supportingDocument.noFilename": "Zonder titel",
+  "taxIdentificationNumber.germanInfo": "Als het belastingidentificatienummer niet wordt verstrekt tijdens de onboarding, wordt dit per e-mail gevraagd. Als het nummer niet binnen 90 dagen wordt verstrekt, schorten we het account op.",
   "wizard.back": "Vorige",
   "wizard.finalize": "Afronden",
   "wizard.next": "Volgende"

--- a/clients/onboarding/src/locales/pt.json
+++ b/clients/onboarding/src/locales/pt.json
@@ -161,6 +161,7 @@
   "supportLink.individualAvailableCountries": "https://support.swan.io/hc/en-150/articles/5767279299741-Am-I-eligible-to-open-an-account-",
   "supportLink.uboDetails": "https://support.swan.io/en/articles/5000716-what-are-ultimate-beneficial-owners-where-do-i-find-my-company-s-ubos",
   "supportingDocument.noFilename": "(Caso contrário, teremos que fazé-lo por email mais tarde.)\"",
+  "taxIdentificationNumber.germanInfo": "Se o número de identificação fiscal não for fornecido durante a adesão, será solicitado por e-mail. Se não for fornecido dentro de 90 dias, suspenderemos a conta.",
   "wizard.back": "Anterior",
   "wizard.finalize": "Finalizar",
   "wizard.next": "Próximo"

--- a/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
+++ b/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
@@ -1,5 +1,6 @@
 import { Result } from "@swan-io/boxed";
 import { Box } from "@swan-io/lake/src/components/Box";
+import { LakeAlert } from "@swan-io/lake/src/components/LakeAlert";
 import { LakeLabel } from "@swan-io/lake/src/components/LakeLabel";
 import { LakeText } from "@swan-io/lake/src/components/LakeText";
 import { LakeTextInput } from "@swan-io/lake/src/components/LakeTextInput";
@@ -298,7 +299,17 @@ export const OnboardingCompanyOrganisation1 = ({
               <StepTitle isMobile={small}>{t("company.step.organisation1.title")}</StepTitle>
               <Space height={small ? 24 : 32} />
 
-              <Tile>
+              <Tile
+                footer={
+                  country === "DEU" ? (
+                    <LakeAlert
+                      variant="info"
+                      anchored={true}
+                      title={t("taxIdentificationNumber.germanInfo")}
+                    />
+                  ) : undefined
+                }
+              >
                 <Field name="isRegistered">
                   {({ value, onChange }) => (
                     <LakeLabel

--- a/clients/onboarding/src/pages/v2individual/OnboardingIndividualDetails.tsx
+++ b/clients/onboarding/src/pages/v2individual/OnboardingIndividualDetails.tsx
@@ -1,4 +1,5 @@
 import { Result } from "@swan-io/boxed";
+import { LakeAlert } from "@swan-io/lake/src/components/LakeAlert";
 import { LakeLabel } from "@swan-io/lake/src/components/LakeLabel";
 import { Item, LakeSelect } from "@swan-io/lake/src/components/LakeSelect";
 import { LakeText } from "@swan-io/lake/src/components/LakeText";
@@ -159,7 +160,17 @@ export const OnboardingIndividualDetails = ({
               <StepTitle isMobile={small}>{t("individual.step.details.title")}</StepTitle>
               <Space height={small ? 24 : 32} />
 
-              <Tile>
+              <Tile
+                footer={
+                  country === "DEU" ? (
+                    <LakeAlert
+                      variant="info"
+                      anchored={true}
+                      title={t("taxIdentificationNumber.germanInfo")}
+                    />
+                  ) : undefined
+                }
+              >
                 <Field name="employmentStatus">
                   {({ value, onChange }) => (
                     <LakeLabel


### PR DESCRIPTION
This PR adds an info alert below tax identification number input only for german accounts: 
![Screenshot 2023-06-19 at 16 53 26](https://github.com/swan-io/swan-partner-frontend/assets/32013054/884beed5-5714-4d44-8e2c-743db005c7f8)
![Screenshot 2023-06-19 at 16 55 20](https://github.com/swan-io/swan-partner-frontend/assets/32013054/a0a7ab44-368a-4d31-8f59-5d37d8e0af92)
