### PR TITLE
adapt register name for french association

### DIFF
--- a/clients/onboarding/src/pages/v2company/CompanyOnboardingWizard.tsx
+++ b/clients/onboarding/src/pages/v2company/CompanyOnboardingWizard.tsx
@@ -370,6 +370,7 @@ export const OnboardingCompanyWizard = ({ onboarding, onboardingId, holder }: Pr
             previousStep="OnboardingRegistration"
             nextStep="OnboardingOrganisation2"
             onboardingId={params.onboardingId}
+            companyType={companyType}
             initialIsRegistered={isRegistered}
             initialName={holder.name ?? ""}
             initialRegistrationNumber={holder.registrationNumber ?? ""}

--- a/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
+++ b/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
@@ -27,6 +27,7 @@ import { OnboardingStepContent } from "../../components/OnboardingStepContent";
 import { StepTitle } from "../../components/StepTitle";
 import {
   AccountCountry,
+  CompanyType,
   GetCompanyInfoDocument,
   UpdateCompanyOnboardingDocument,
 } from "../../graphql/unauthenticated";
@@ -60,6 +61,7 @@ export type Organisation1FieldName =
 type Props = {
   previousStep: CompanyOnboardingRoute;
   nextStep: CompanyOnboardingRoute;
+  companyType: CompanyType;
   initialIsRegistered: boolean;
   initialName: string;
   initialRegistrationNumber: string;
@@ -77,6 +79,10 @@ type Props = {
   }[];
 };
 
+const associationRegisterNamePerCountry: Partial<Record<CountryCCA3, string>> = {
+  FRA: "RNA",
+};
+
 const registerNamePerCountry: Partial<Record<CountryCCA3, string>> = {
   BEL: "“Code des sociétés”",
   DEU: "Handelsregister",
@@ -88,6 +94,7 @@ const registerNamePerCountry: Partial<Record<CountryCCA3, string>> = {
 export const OnboardingCompanyOrganisation1 = ({
   previousStep,
   nextStep,
+  companyType,
   initialIsRegistered,
   initialName,
   initialRegistrationNumber,
@@ -288,7 +295,9 @@ export const OnboardingCompanyOrganisation1 = ({
     [setFieldValue],
   );
 
-  const countryRegisterName = registerNamePerCountry[country];
+  const countryRegisterName = match(companyType)
+    .with("Association", () => associationRegisterNamePerCountry[country])
+    .otherwise(() => registerNamePerCountry[country]);
 
   return (
     <>


### PR DESCRIPTION
Linear ticket: https://linear.app/swan/issue/FRONT-618/onboarding-error-in-association-flow 

In the onboarding, the register name for a french association is `RNA` instead of `RCS`

![Screenshot 2023-06-28 at 09 47 29](https://github.com/swan-io/swan-partner-frontend/assets/32013054/c4d4563d-c1c1-47f2-97da-fd892094aa9d)
