### PR TITLE
fix registration number label for french association

### DIFF
--- a/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
+++ b/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
@@ -386,7 +386,10 @@ export const OnboardingCompanyOrganisation1 = ({
                       {({ value, valid, error, onChange }) => (
                         <LakeLabel
                           label={t("company.step.organisation1.registrationNumberLabel", {
-                            registrationNumberLegalName: getRegistrationNumberName(country),
+                            registrationNumberLegalName: getRegistrationNumberName(
+                              country,
+                              companyType,
+                            ),
                           })}
                           optionalLabel={isRegistered.value ? undefined : t("common.optional")}
                           render={id => (

--- a/clients/onboarding/src/utils/templateTranslations.ts
+++ b/clients/onboarding/src/utils/templateTranslations.ts
@@ -1,6 +1,7 @@
 import { CountryCCA3 } from "@swan-io/shared-business/src/constants/countries";
 import { match, P } from "ts-pattern";
 import type { CombinedError } from "urql";
+import { CompanyType } from "../graphql/unauthenticated";
 import { t } from "./i18n";
 
 export const getErrorFieldLabel = (field: string) => {
@@ -72,7 +73,7 @@ export const getUpdateOnboardingError = (
     });
 };
 
-export const getRegistrationNumberName = (country: CountryCCA3) => {
+export const getRegistrationNumberName = (country: CountryCCA3, companyType: CompanyType) => {
   const name = match(country)
     .with("AUT", () => "Firmenbuchnummer")
     .with("BEL", () => "Numéro d'entreprise / Vestigingseenheidsnummer")
@@ -82,7 +83,7 @@ export const getRegistrationNumberName = (country: CountryCCA3) => {
     .with("DNK", () => "CVR-nummer")
     .with("EST", () => "Kood")
     .with("FIN", () => "Y-tunnus FO-nummer")
-    .with("FRA", () => "Numéro SIREN")
+    .with("FRA", () => (companyType === "Association" ? "RNA" : "Numéro SIREN"))
     .with("DEU", () => "Nummer der Firma Registernummer")
     .with(
       "GRC",


### PR DESCRIPTION
This PR fixes registration number name for french association:

![Screenshot 2023-06-28 at 14 26 57](https://github.com/swan-io/swan-partner-frontend/assets/32013054/8433b3af-fc0a-4337-a4a8-8c6a983c2b78)
