### PR TITLE
fix registred label for association

### DIFF
--- a/clients/onboarding/src/locales/de.json
+++ b/clients/onboarding/src/locales/de.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "Ist deine Firma bereits im {countryRegisterName} eingetragen?",
   "company.step.organisation1.organisationLabel": "Deine Organisation",
   "company.step.organisation1.organisationPlaceholder": "Gebe den Namen deiner Organisation ein",
-  "company.step.organisation1.registrationNumberLabel": "Wie lautet deine Registrierungsnummer {registrationNumberLegalName}?",
+  "company.step.organisation1.registrationNumberLabel": "Wie lautet deine Registrierungsnummer{registrationNumberLegalName}?",
   "company.step.organisation1.registrationNumberPlaceholder": "Gebe deine Nummer ein",
   "company.step.organisation1.title": "Rechtliche Informationen",
   "company.step.organisation1.vatLabel": "Wie lautet deine USt-ID?",

--- a/clients/onboarding/src/locales/en.json
+++ b/clients/onboarding/src/locales/en.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "Are you registered to {countryRegisterName}?",
   "company.step.organisation1.organisationLabel": "Your organization",
   "company.step.organisation1.organisationPlaceholder": "Type your organization name",
-  "company.step.organisation1.registrationNumberLabel": "What’s your registration number ({registrationNumberLegalName})?",
+  "company.step.organisation1.registrationNumberLabel": "What’s your registration number{registrationNumberLegalName}?",
   "company.step.organisation1.registrationNumberPlaceholder": "Enter your number",
   "company.step.organisation1.title": "Legal information",
   "company.step.organisation1.vatLabel": "What’s your VAT number?",

--- a/clients/onboarding/src/locales/es.json
+++ b/clients/onboarding/src/locales/es.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "¿Tu organización está registrada en {countryRegisterName}?",
   "company.step.organisation1.organisationLabel": "Tu organización",
   "company.step.organisation1.organisationPlaceholder": "Escribe el nombre de tu organización",
-  "company.step.organisation1.registrationNumberLabel": "¿Cuál es el número de registro de tu organización?",
+  "company.step.organisation1.registrationNumberLabel": "¿Cuál es el número de registro de tu organización{registrationNumberLegalName}?",
   "company.step.organisation1.registrationNumberPlaceholder": "Introduce tu número",
   "company.step.organisation1.title": "Información jurídica",
   "company.step.organisation1.vatLabel": "¿Cuál es tu número de IVA?",

--- a/clients/onboarding/src/locales/fr.json
+++ b/clients/onboarding/src/locales/fr.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "Êtes-vous immatriculé au {countryRegisterName} ?",
   "company.step.organisation1.organisationLabel": "Votre organisation",
   "company.step.organisation1.organisationPlaceholder": "Saisissez le nom de votre organisation",
-  "company.step.organisation1.registrationNumberLabel": "Quel est votre numéro d'immatriculation ({registrationNumberLegalName}) ?",
+  "company.step.organisation1.registrationNumberLabel": "Quel est votre numéro d'immatriculation{registrationNumberLegalName} ?",
   "company.step.organisation1.registrationNumberPlaceholder": "Saisissez votre numéro",
   "company.step.organisation1.title": "Informations juridiques",
   "company.step.organisation1.vatLabel": "Quel est votre numéro de TVA ?",

--- a/clients/onboarding/src/locales/it.json
+++ b/clients/onboarding/src/locales/it.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "Sei registrato in {countryRegisterName}?",
   "company.step.organisation1.organisationLabel": "La tua organizzazione",
   "company.step.organisation1.organisationPlaceholder": "Digita il nome dell'organizzazione",
-  "company.step.organisation1.registrationNumberLabel": "Qual è il numero di registrazione di ({registrationNumberLegalName})?",
+  "company.step.organisation1.registrationNumberLabel": "Qual è il numero di registrazione di{registrationNumberLegalName}?",
   "company.step.organisation1.registrationNumberPlaceholder": "Digita il numero",
   "company.step.organisation1.title": "Informazioni legali",
   "company.step.organisation1.vatLabel": "Qual è il tuo numero di partita IVA?",

--- a/clients/onboarding/src/locales/nl.json
+++ b/clients/onboarding/src/locales/nl.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "Ben je geregistreerd bij {countryRegisterName}?",
   "company.step.organisation1.organisationLabel": "Jouw organisatie",
   "company.step.organisation1.organisationPlaceholder": "Typ de naam van je organisatie",
-  "company.step.organisation1.registrationNumberLabel": "Wat is je registratienummer ({registrationNumberLegalName})?",
+  "company.step.organisation1.registrationNumberLabel": "Wat is je registratienummer{registrationNumberLegalName}?",
   "company.step.organisation1.registrationNumberPlaceholder": "Typ je nummer",
   "company.step.organisation1.title": "Juridische informatie",
   "company.step.organisation1.vatLabel": "Wat is je BTW-nummer?",

--- a/clients/onboarding/src/locales/pt.json
+++ b/clients/onboarding/src/locales/pt.json
@@ -31,7 +31,7 @@
   "company.step.organisation1.isRegisteredWithNameLabel": "Você está registado em {countryRegisterName}?",
   "company.step.organisation1.organisationLabel": "A sua organização",
   "company.step.organisation1.organisationPlaceholder": "Introduza o nome da sua organização",
-  "company.step.organisation1.registrationNumberLabel": "Qual o seu número de registo ({registrationNumberLegalName})?",
+  "company.step.organisation1.registrationNumberLabel": "Qual o seu número de registo{registrationNumberLegalName}?",
   "company.step.organisation1.registrationNumberPlaceholder": "Introduza o seu número",
   "company.step.organisation1.title": "Informação legal",
   "company.step.organisation1.vatLabel": "Qual é o seu número de IVA?",

--- a/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
+++ b/clients/onboarding/src/pages/v2company/OnboardingCompanyOrganisation1.tsx
@@ -80,7 +80,7 @@ type Props = {
 };
 
 const associationRegisterNamePerCountry: Partial<Record<CountryCCA3, string>> = {
-  FRA: "RNA",
+  FRA: "RCS/JOAFE",
 };
 
 const registerNamePerCountry: Partial<Record<CountryCCA3, string>> = {

--- a/clients/onboarding/src/utils/templateTranslations.ts
+++ b/clients/onboarding/src/utils/templateTranslations.ts
@@ -77,7 +77,7 @@ export const getRegistrationNumberName = (country: CountryCCA3, companyType: Com
   const name = match(country)
     .with("AUT", () => "Firmenbuchnummer")
     .with("BEL", () => "Numéro d'entreprise / Vestigingseenheidsnummer")
-    .with("HRV", () => "Matični broj poslovnog subjekta (MBS)")
+    .with("HRV", () => "Matični broj poslovnog subjekta [MBS]")
     .with("CYP", () => "Αριθμός Μητρώου Εταιρίας Şirket kayıt numarası")
     .with("CZE", () => "Identifikační číslo")
     .with("DNK", () => "CVR-nummer")
@@ -87,7 +87,7 @@ export const getRegistrationNumberName = (country: CountryCCA3, companyType: Com
     .with("DEU", () => "Nummer der Firma Registernummer")
     .with(
       "GRC",
-      () => "τον Αριθμό Γενικού Εμπορικού Μητρώου τον Αριθμό Φορολογικού Μητρώου (Α.Φ.Μ.)",
+      () => "τον Αριθμό Γενικού Εμπορικού Μητρώου τον Αριθμό Φορολογικού Μητρώου [Α.Φ.Μ.]",
     )
     .with("HUN", () => "Cégjegyzékszáma")
     .with("IRL", () => "Company Number")
@@ -100,17 +100,17 @@ export const getRegistrationNumberName = (country: CountryCCA3, companyType: Com
     .with("MLT", () => "Registration Number")
     .with("NLD", () => "KvK-nummer")
     .with("NOR", () => "TIN")
-    .with("POL", () => "Numer w Krajowym Rejestrze Sądowym (numer KRS)")
-    .with("PRT", () => "Número de Identificação Pessoa Coletiva (NIPC)")
+    .with("POL", () => "Numer w Krajowym Rejestrze Sądowym [numer KRS]")
+    .with("PRT", () => "Número de Identificação Pessoa Coletiva [NIPC]")
     .with("ROU", () => "Număr de ordine în Registrul Comerţului")
     .with("SVK", () => "Identifikačného čísla Identification number")
     .with("SVN", () => "Matična številka")
-    .with("ESP", () => "Número de identificación fiscal (NIF)")
+    .with("ESP", () => "Número de identificación fiscal [NIF]")
     .with("SWE", () => "Registreringsnummer")
-    .otherwise(() => null);
+    .otherwise(() => "");
 
   if (name == null) {
     return "";
   }
-  return ` - ${name}`;
+  return ` (${name})`;
 };

--- a/clients/onboarding/src/utils/templateTranslations.ts
+++ b/clients/onboarding/src/utils/templateTranslations.ts
@@ -107,7 +107,7 @@ export const getRegistrationNumberName = (country: CountryCCA3, companyType: Com
     .with("SVN", () => "Matična številka")
     .with("ESP", () => "Número de identificación fiscal [NIF]")
     .with("SWE", () => "Registreringsnummer")
-    .otherwise(() => "");
+    .otherwise(() => null);
 
   if (name == null) {
     return "";


### PR DESCRIPTION
Linear ticket: https://linear.app/swan/issue/FRONT-621/update-on-the-association-flow

This PR is about registration labels in onboarding:

1️⃣  Fix `Are you registered` label for associations:
![Screenshot 2023-06-29 at 09 59 32](https://github.com/swan-io/swan-partner-frontend/assets/32013054/fab3018f-9316-4b6a-8de2-8c361ae3d251)

2️⃣ Fix mix between `-` and `()`:  
This PR removes parenthesis in translation and add them in code if we find a registration number name depending on country. And we replaces `()` by `[]`  
Before:  
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/919c5190-d738-48e2-b8a2-53c0d1de7aee)
After:  
![image](https://github.com/swan-io/swan-partner-frontend/assets/32013054/5d22098b-7440-4bc9-8fb0-1dca29da6d1c)
