### PR TITLE
v1.8.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": ">=18.0.0",

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": ">=18.0.0",

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": ">=18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": ">=20.9.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
## What's Changed

- Only display alert when fallback transaction is Pending (#585) (854c75a)
- Make unavailable account statements non-clickable (#586) (7bc189e)
- Add tag for canceled standing order tag (#577) (001f1c7)
- Add a link to MasterCard business bonus offers (#587) (9d5cd5e)
- Add missing translation on individual onboarding (#594) (3f4e92a)
- Add security header (#597) (710b0ec)
- Remove deprecated `identificationStatus` usage (#596) (136a4a0)
- Add E2E back (#598) (260c43e)

**Full Changelog**: https://github.com/swan-io/swan-partner-frontend/compare/v1.7.2...v1.8.0