### PR TITLE
Fixed IBAN validation request failing

### DIFF
--- a/clients/banking/src/components/TransferRegularWizardSchedule.tsx
+++ b/clients/banking/src/components/TransferRegularWizardSchedule.tsx
@@ -15,6 +15,7 @@ import { animations, colors } from "@swan-io/lake/src/constants/design";
 import { useUrqlQuery } from "@swan-io/lake/src/hooks/useUrqlQuery";
 import { DatePicker, isDateInRange } from "@swan-io/shared-business/src/components/DatePicker";
 import dayjs from "dayjs";
+import { electronicFormat } from "iban";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { combineValidators, useForm } from "react-ux-form";
 import { Rifm } from "rifm";
@@ -74,7 +75,7 @@ export const TransferRegularWizardSchedule = ({
     {
       query: GetIbanValidationDocument,
       variables: {
-        iban: beneficiary.iban.replaceAll(" ", ""),
+        iban: electronicFormat(beneficiary.iban),
       },
     },
     [beneficiary.iban],

--- a/clients/banking/src/components/TransferRegularWizardSchedule.tsx
+++ b/clients/banking/src/components/TransferRegularWizardSchedule.tsx
@@ -74,7 +74,7 @@ export const TransferRegularWizardSchedule = ({
     {
       query: GetIbanValidationDocument,
       variables: {
-        iban: beneficiary.iban,
+        iban: beneficiary.iban.replaceAll(" ", ""),
       },
     },
     [beneficiary.iban],

--- a/clients/banking/src/components/TransferWizardBeneficiary.tsx
+++ b/clients/banking/src/components/TransferWizardBeneficiary.tsx
@@ -45,7 +45,7 @@ export const TransferWizardBeneficiary = ({ initialBeneficiary, onSave }: Props)
       pause: iban == undefined,
       variables: {
         // `pause` gives us the guarantee we get a valid iban
-        iban: (iban as string)?.replaceAll(" ", ""),
+        iban: electronicFormat(iban as string),
       },
     },
     [iban],

--- a/clients/banking/src/components/TransferWizardBeneficiary.tsx
+++ b/clients/banking/src/components/TransferWizardBeneficiary.tsx
@@ -45,7 +45,7 @@ export const TransferWizardBeneficiary = ({ initialBeneficiary, onSave }: Props)
       pause: iban == undefined,
       variables: {
         // `pause` gives us the guarantee we get a valid iban
-        iban: iban as string,
+        iban: (iban as string)?.replaceAll(" ", ""),
       },
     },
     [iban],


### PR DESCRIPTION
The IBAN validation expects the IBAN without spaces and returns a lengths validation error otherwise

this leads to the recipient bank not being shown