### PR TITLE
v1.16.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",


### PR DESCRIPTION
### What's Included

- Only show reveal card number on previous card when renewing (#750)
- Simplify card query using new accountId on membership (#751)
- Disable language select field when membership is suspended (#752)
- Fix the session expired message when opening the web banking (#753)
- Fix logic for card order when canViewAccount is false (#754)
- Stop waiting for async data (#756)
- Add address selection for physical card order with no canViewAccount (#755)
- Add partnership condition (#758)
- Don't display buttons if the previous card is expired (#757)
- Card payment link (#719)
- Forward errors to logs (#759)
- Switch to @sentry/browser (#760)
- Hide validated documents from collection interface (#761)
- Remove amex card from approved cards in payment link (#763)
- Rename accountLanguage prop to accountMembershipLanguage (#764)
- Update lake (#765)
- Update wording for blocking physical cards modals (#766)
- Update release script (#767)
- Add back missing version step (#769)
- Fix
- Don't use package.json version for the diff, as the associated tag might not exists (#770)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.15.0..release-v1.16.0