### PR TITLE
v1.17.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.16.10",
+  "version": "1.17.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.16.10",
+  "version": "1.17.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.16.10",
+  "version": "1.17.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.16.10",
+  "version": "1.17.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.16.10",
+  "version": "1.17.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",


### PR DESCRIPTION
### What's Included

- Let members with `canInitiatePayments` and without `canViewAccount` (#823)
- Remove downloadUrl from scheme (#824)
- Add support for merchant enriched data (#820)
- Add trusted international beneficiary (#812)
- Update lake (#825)
- Apply feedback to enriched data (#829)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.16.10..release-v1.17.0