### PR TITLE
v1.18.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.17.10",
+  "version": "1.18.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.17.10",
+  "version": "1.18.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.17.10",
+  "version": "1.18.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.17.10",
+  "version": "1.18.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.17.10",
+  "version": "1.18.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",


### PR DESCRIPTION
### What's Included

- Add name validation on UBOs (#875)
- Adapt card querying to correct permission (#876)
- Add ownership step for associations located in NLD (#878)
- Improve merchant payment method tile styling (#877)
- Add noindex (#879)
- Create WizardLayout component (#880)
- Make VAT number mandatory when account country is ITA (#881)
- Add missing separator (#883)
- Use company country as default UBO birth/residency (#885)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.17.10..release-v1.18.0