### PR TITLE
v1.21.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "private": true,
   "engines": {
     "node": ">=18.20.0",


### PR DESCRIPTION
### What's Included

- fix: removed duplicate birth date label (#914)
- Add close account UI (#915)
- Remove account_contract_choose_pin_code_enabled flag (#916)
- Allow `0` in beneficiary names (#918)
- Cleanup `beneficiaries` feature flag (#920)
- Add support for transaction statement download (FRONT-1155) (#919)
- Pass `accountMembershipId` query param to OAuth2 login url (#921)
- Forward email param to OAuth2 login url (#922)
- Use account language for transaction statement if accessible (#923)
- Update lake (#924)
- update translations from localazy (#913)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.20.2..release-v1.21.0