### PR TITLE
v1.22.21

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.22.20",
+  "version": "1.22.21",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.22.20",
+  "version": "1.22.21",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.22.20",
+  "version": "1.22.21",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.22.20",
+  "version": "1.22.21",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.22.20",
+  "version": "1.22.21",
   "private": true,
   "packageManager": "pnpm@9.9.0",
   "engines": {


### PR DESCRIPTION
### What's Included

- [onboarding] Remove monaco from residency address / [payment] Fix redirection success page for SDD   (#979)
- Fix validation hour issue in recurring transfer (#981)
- Switch to pnpm (#980)
- Update to docusaurus 3 (#982)
- Fix precommit script (#983)
- Fix dockerfile (#984)
- Fix internal Dockerfile start command

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.22.20..release-v1.22.21