### PR TITLE
v1.24.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.23.13",
+  "version": "1.24.0",
   "private": true,
   "packageManager": "pnpm@9.13.0",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.23.13",
+  "version": "1.24.0",
   "private": true,
   "packageManager": "pnpm@9.13.0",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.23.13",
+  "version": "1.24.0",
   "private": true,
   "packageManager": "pnpm@9.13.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.23.13",
+  "version": "1.24.0",
   "private": true,
   "packageManager": "pnpm@9.13.0",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.23.13",
+  "version": "1.24.0",
   "private": true,
   "packageManager": "pnpm@9.13.0",
   "engines": {


### PR DESCRIPTION
### What's Included

- put merchant tab behind flag (#1053)
- Fix E2E translation (#1055)
- Use less agressive linting rules (#1056)
- Add reason code to refused supporting documents (#1058)
- feat: validate the address according to the specification (#1057)
- Update deps + eslint v9 (#1059)
- Update request library (#1060)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.23.13..release-v1.24.0