### PR TITLE
Apply `recommendedIdentificationLevel` deprecation

### DIFF
--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -155,7 +155,7 @@ type Props = {
   accountMembership: NonNullable<AccountAreaQuery["accountMembership"]>;
   user: NonNullable<AccountAreaQuery["user"]>;
   projectInfo: NonNullable<AccountAreaQuery["projectInfo"]>;
-  lastRelevantIdentification: Option<IdentificationFragment>;
+  lastIdentification: Option<IdentificationFragment>;
   shouldDisplayIdVerification: boolean;
   requireFirstTransfer: boolean;
   activationTag: AccountActivationTag;
@@ -169,7 +169,7 @@ export const AccountArea = ({
   projectInfo,
   user,
   activationTag,
-  lastRelevantIdentification,
+  lastIdentification,
   shouldDisplayIdVerification,
   requireFirstTransfer,
   reload,
@@ -458,7 +458,7 @@ export const AccountArea = ({
                           <AccountActivationPage
                             requireFirstTransfer={requireFirstTransfer}
                             hasRequiredIdentificationLevel={hasRequiredIdentificationLevel}
-                            lastRelevantIdentification={lastRelevantIdentification}
+                            lastIdentification={lastIdentification}
                             accentColor={accentColor}
                             accountMembershipId={accountMembershipId}
                             additionalInfo={additionalInfo}
@@ -474,7 +474,7 @@ export const AccountArea = ({
                                 account?.balances?.available.value != null
                                   ? Number(account?.balances?.available.value)
                                   : null,
-                              lastRelevantIdentification: lastRelevantIdentification.map(
+                              lastIdentification: lastIdentification.map(
                                 getIdentificationLevelStatusInfo,
                               ),
                             })
@@ -540,7 +540,7 @@ export const AccountArea = ({
                                       idVerifiedMatchError: true,
                                     },
                                   },
-                                  lastRelevantIdentification: Option.P.Some({ status: "Pending" }),
+                                  lastIdentification: Option.P.Some({ status: "Pending" }),
                                 },
                                 () => (
                                   <ResponsiveContainer breakpoint={breakpoints.large}>
@@ -833,7 +833,7 @@ export const AccountArea = ({
                                 permissions.canReadAccountDetails ? (
                                   <AccountActivationPage
                                     hasRequiredIdentificationLevel={hasRequiredIdentificationLevel}
-                                    lastRelevantIdentification={lastRelevantIdentification}
+                                    lastIdentification={lastIdentification}
                                     requireFirstTransfer={requireFirstTransfer}
                                     accentColor={accentColor}
                                     accountMembershipId={accountMembershipId}
@@ -867,7 +867,7 @@ export const AccountArea = ({
 
               {largeViewport ? null : (
                 <NavigationTabBar
-                  identificationStatusInfo={lastRelevantIdentification.map(
+                  identificationStatusInfo={lastIdentification.map(
                     getIdentificationLevelStatusInfo,
                   )}
                   hasRequiredIdentificationLevel={hasRequiredIdentificationLevel}

--- a/clients/banking/src/graphql/partner.gql
+++ b/clients/banking/src/graphql/partner.gql
@@ -370,19 +370,12 @@ fragment TrustedBeneficiaryDetails on TrustedBeneficiary {
 
 # Queries
 
-query LastRelevantIdentification(
-  $accountMembershipId: ID!
-  $identificationProcess: [IdentificationProcess!]
-) {
+query LastIdentification($accountMembershipId: ID!) {
   accountMembership(id: $accountMembershipId) {
     id
     user {
       id
-      identifications(
-        first: 1
-        orderBy: { field: updatedAt, direction: Desc }
-        filters: { processes: $identificationProcess }
-      ) {
+      identifications(first: 1, orderBy: { field: updatedAt, direction: Desc }) {
         edges {
           node {
             ...Identification
@@ -927,7 +920,6 @@ query CardPage($cardId: ID!) {
     accountMembership {
       id
       canManageAccountMembership
-      recommendedIdentificationLevel
       hasRequiredIdentificationLevel
       canViewAccount
       canManageBeneficiaries
@@ -1083,7 +1075,6 @@ query CardTransactionsPage(
     }
     accountMembership {
       id
-      recommendedIdentificationLevel
       statusInfo {
         __typename
         ... on AccountMembershipBindingUserErrorStatusInfo {
@@ -1260,7 +1251,6 @@ fragment AccountMembership on AccountMembership {
   updatedAt
   email
   legalRepresentative
-  recommendedIdentificationLevel
   hasRequiredIdentificationLevel
   language
   statusInfo {
@@ -1403,7 +1393,6 @@ query ProfilePage {
 query AccountActivationPage($accountMembershipId: ID!) {
   accountMembership(id: $accountMembershipId) {
     id
-    recommendedIdentificationLevel
     account {
       id
       IBAN

--- a/clients/banking/src/pages/AccountActivationPage.tsx
+++ b/clients/banking/src/pages/AccountActivationPage.tsx
@@ -296,7 +296,7 @@ type Props = {
   refetchAccountAreaQuery: () => void;
   requireFirstTransfer: boolean;
   hasRequiredIdentificationLevel: boolean | undefined;
-  lastRelevantIdentification: Option<IdentificationFragment>;
+  lastIdentification: Option<IdentificationFragment>;
 };
 
 export const AccountActivationPage = ({
@@ -307,7 +307,7 @@ export const AccountActivationPage = ({
   refetchAccountAreaQuery,
   requireFirstTransfer,
   hasRequiredIdentificationLevel,
-  lastRelevantIdentification,
+  lastIdentification,
 }: Props) => {
   const documentsFormRef = useRef<SupportingDocumentsFormRef>(null);
 
@@ -377,7 +377,7 @@ export const AccountActivationPage = ({
               hasRequiredIdentificationLevel: false,
             },
             () =>
-              match(lastRelevantIdentification.map(getIdentificationLevelStatusInfo))
+              match(lastIdentification.map(getIdentificationLevelStatusInfo))
                 .returnType<Step | undefined>()
                 // this branch shouldn't occur but is required to typecheck
                 .with(Option.P.Some({ status: P.union("Valid", "NotSupported") }), () => undefined)
@@ -528,7 +528,7 @@ export const AccountActivationPage = ({
                       <Space height={32} />
 
                       <LakeButton mode="primary" color="partner" onPress={handleProveIdentity}>
-                        {lastRelevantIdentification.map(isReadyToSign).getOr(false)
+                        {lastIdentification.map(isReadyToSign).getOr(false)
                           ? t("accountActivation.identity.button.signVerification")
                           : t("accountActivation.identity.button.verifyMyIdentity")}
                       </LakeButton>


### PR DESCRIPTION
Identification are now less relevant but let's keep the logic for
**not** showing the "Identify" button when the last identification is
processing. That avoids a deceptive effect.
