### PR TITLE
v1.24.12

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.24.11",
+  "version": "1.24.12",
   "private": true,
   "packageManager": "pnpm@10.2.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.24.11",
+  "version": "1.24.12",
   "private": true,
   "packageManager": "pnpm@10.2.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.24.11",
+  "version": "1.24.12",
   "private": true,
   "packageManager": "pnpm@10.2.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.24.11",
+  "version": "1.24.12",
   "private": true,
   "packageManager": "pnpm@10.2.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.24.11",
+  "version": "1.24.12",
   "private": true,
   "packageManager": "pnpm@10.2.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- Handle empty strings as tracking numbers (#1120)
- Front 1255 add rolling reserve amount and release date in details panel (#1121)
- Merchant fixes: don't send empty string for reference, add finnish language support (#1123)
- Add merchant profile request update (#1124)
- Use `updateOnboarding` to autofill company details (#1122)
- Use larger search fields (#1125)
- Use `updateOnboarding` to autofill company details (#1126)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.24.11..release-v1.24.12