### PR TITLE
fix value length rule for beneficiary name to fit with API restrictions [Assoconnect]

### DIFF
--- a/clients/banking/src/utils/validations.ts
+++ b/clients/banking/src/utils/validations.ts
@@ -61,7 +61,7 @@ export const validateBeneficiaryName: Validator<string> = value => {
   }
 
   // Rule copied from the backend
-  if (value.length > 100) {
+  if (value.length > 70) {
     return t("common.form.invalidName");
   }
 


### PR DESCRIPTION
Some users received an "Access denied" on transfers. 

After investigation, we noticed that they were attempting to make transfers with long beneficiary names. The API returns an error for account holder names longer than 70 characters.