### PR TITLE
[Banking] Payment method status shouldn't be exhaustive

### DIFF
--- a/clients/banking/src/components/MerchantProfileSettings.tsx
+++ b/clients/banking/src/components/MerchantProfileSettings.tsx
@@ -209,7 +209,7 @@ const MerchantProfileSettingsPaymentMethodTile = ({
               </Tag>
             ))
             .with(P.nullish, () => null)
-            .exhaustive()}
+            .otherwise(() => null)}
 
           <Fill minWidth={8} />
 


### PR DESCRIPTION
Merchant team will add a new status to payment method status. I put an otherwise instead of exhaustive to avoid the front break
https://swan-bank.slack.com/archives/C04G7RV1L49/p1751458984201479?thread_ts=1751375145.857299&cid=C04G7RV1L49