### PR TITLE
v1.25.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.24.31",
+  "version": "1.25.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.24.31",
+  "version": "1.25.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.24.31",
+  "version": "1.25.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.24.31",
+  "version": "1.25.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.24.31",
+  "version": "1.25.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {


### PR DESCRIPTION
### What's Included

- Fix production build (#1210)
- Update lake (#1211)
- Update lake + rollback react-native-web (#1212)
- Use OTEL Node SDK (#1213)
- Fix request ID header logic (#1215)
- update graphql-client (#1216)
- validate birth date for UBOs (#1217)
- Use vite middleware mode (#1218)
- Force optimize deps (#1219)
- add sworn statement templates in additional languages (#1220)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.24.31..release-v1.25.0