### PR TITLE
display account activation button when user didn't start his first identification

### DIFF
--- a/clients/banking/src/components/AccountArea.tsx
+++ b/clients/banking/src/components/AccountArea.tsx
@@ -379,7 +379,7 @@ export const AccountArea = ({
 
                   <Space height={32} />
 
-                  {activationTag === "pending" && (
+                  {(activationTag === "pending" || activationTag === "actionRequired") && (
                     <LakeButton
                       color="current"
                       icon="checkmark-starburst-filled"

--- a/clients/banking/src/components/NavigationTabBar.tsx
+++ b/clients/banking/src/components/NavigationTabBar.tsx
@@ -277,7 +277,7 @@ export const NavigationTabBar = ({
 
                   <Space height={24} />
 
-                  {activationTag === "pending" && (
+                  {(activationTag === "pending" || activationTag === "actionRequired") && (
                     <LakeButton
                       color="current"
                       icon="checkmark-starburst-filled"


### PR DESCRIPTION
## Before
<img width="1719" height="890" alt="Screenshot 2025-10-03 at 17 38 55" src="https://github.com/user-attachments/assets/03d2ec5e-fe2b-4b77-86be-7f3ba481e0d3" />
<img width="658" height="567" alt="Screenshot 2025-10-03 at 17 39 09" src="https://github.com/user-attachments/assets/d7bcf2e4-f8dc-4e09-a644-f53db87b02e4" />

## After
<img width="1706" height="860" alt="Screenshot 2025-10-03 at 17 38 37" src="https://github.com/user-attachments/assets/86dccbfb-20f3-465d-a685-a7f6c2575295" />
<img width="681" height="634" alt="Screenshot 2025-10-03 at 17 39 43" src="https://github.com/user-attachments/assets/ed18fc51-b1e8-4d72-9c85-d74cd51cad28" />

