### PR TITLE
v1.33.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.32.9",
+  "version": "1.33.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.32.9",
+  "version": "1.33.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.32.9",
+  "version": "1.33.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.32.9",
+  "version": "1.33.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.32.9",
+  "version": "1.33.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- feat: add ContextMenu component #FRONT-1770 (#1591)
- Update lake to remove tooltip taxid (#1592)
- update translations from localazy (#1593)
- feat: revamp card settings tab FRONT-1722 (#1594)
- Show missing input by default when prefilled (#1595)
- update translations from localazy (#1596)
- feat: revamp card wizard #FRONT-1722 (#1597)
- fix: make addressLine2 in re-kyc form optional (#1598)
- force lodash upgrade (#1599)
- fix lodash version in docs (#1601)
- sanitize tax identification value (#1602)
- fix: revamp card settings design fixes  #FRONT-1722 (#1600)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.32.9..release-v1.33.0