### PR TITLE
v1.33.1

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- display specific error view if ICT form is unavailable (#1604)
- update translations from localazy (#1606)
- revamp card product list design (#1605)
- Fix select option for onboarding headcount (#1611)
- fix: make SUVC periodicity non-editable and remove choice picker (#1612)
- fix: add context menu styles (#1610)
- fix: wording and link display for insurance claim (#1608)
- Update lake (#1614)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.33.0..release-v1.33.1