### PR TITLE
v1.34.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- Update lake to add sticky search in LakeSelect (#1616)
- feat: use input phone number #FRONT-1810 (#1609)
- add columns in account statements modal (#1618)
- Update lake (#1620)
- chore: replace MobileStepTitle by new component MobileStepper (#1621)
- change selected card format color (#1623)
- Update segmented control (#1624)
- feat: replace MobileStepTitle with MobileStepper (#1625)
- Front 1879 onboarding v2 prefilled data without user information (#1626)
- Update lake (#1627)
- order account statements by opening date (#1619)
- update merchant link preview width (#1630)
- chore: revert to default values on card ordering flow (#1632)
- chore: add claude ai to review merge requests (#1633)
- update translations from localazy (#1634)
- Update role label and add helper (#1635)
- Remove calendar spending limit flag (#1636)
- make spending limit mode non nullable (#1637)
- update translations from localazy (#1638)
- Front 1859 onboarding v2 conditionally show how are you authorized field (#1639)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.33.1..release-v1.34.0