### PR TITLE
chore: enable noUndeclaredVariables biome linter rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -37,8 +37,9 @@
         "noVoidTypeReturn": "off",
         "useArrayLiterals": "error",
         "useHookAtTopLevel": "warn",
-        "useJsxKeyInIterable": "off"
-      },
+        "useJsxKeyInIterable": "off",
+        "noUndeclaredVariables": "error"
+},
       "nursery": {
         "noCommonJs": "error"
       },


### PR DESCRIPTION
Enable `noUndeclaredVariables: "error"` in `linter.rules.correctness` to catch uses of undeclared variables at lint time.

This rule was missing from the biome configuration — adding it ensures consistency with other repositories in the org (e.g. `scoring`) and prevents accidental use of undeclared/global variables.