### PR TITLE
Add biome rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,9 @@
   "organizeImports": {
     "enabled": false
   },
+  "javascript": {
+    "globals": ["__env", "React", "ILocale", "WizardStep"]
+  },
   "linter": {
     "enabled": true,
     "rules": {
@@ -37,7 +40,8 @@
         "noVoidTypeReturn": "off",
         "useArrayLiterals": "error",
         "useHookAtTopLevel": "warn",
-        "useJsxKeyInIterable": "off"
+        "useJsxKeyInIterable": "off",
+        "noUndeclaredVariables": "error"
       },
       "nursery": {
         "noCommonJs": "error"


### PR DESCRIPTION
Enable noUndeclaredVariables: "error" in linter.rules.correctness to catch uses of undeclared variables at lint time.

This rule was missing from the biome configuration — adding it ensures consistency with other repositories in the org (e.g. scoring) and prevents accidental use of undeclared/global variables.

cf https://github.com/swan-io/swan-partner-frontend/pull/1642