### PR TITLE
Clean flag with Claude command

### DIFF
--- a/clients/banking/src/components/MembershipDetailEditor.tsx
+++ b/clients/banking/src/components/MembershipDetailEditor.tsx
@@ -1,4 +1,4 @@
-import { AsyncData, Option, Result } from "@swan-io/boxed";
+import { Option } from "@swan-io/boxed";
 import { useMutation } from "@swan-io/graphql-client";
 import { Box } from "@swan-io/lake/src/components/Box";
 import { LakeButton, LakeButtonGroup } from "@swan-io/lake/src/components/LakeButton";
@@ -11,7 +11,6 @@ import { identity } from "@swan-io/lake/src/utils/function";
 import { filterRejectionsToResult } from "@swan-io/lake/src/utils/gql";
 import { pick } from "@swan-io/lake/src/utils/object";
 import { trim } from "@swan-io/lake/src/utils/string";
-import { Request, badStatusToError } from "@swan-io/request";
 import { BirthdatePicker } from "@swan-io/shared-business/src/components/BirthdatePicker";
 import { CountryPicker } from "@swan-io/shared-business/src/components/CountryPicker";
 import { InputPhoneNumber } from "@swan-io/shared-business/src/components/InputPhoneNumber";
@@ -33,7 +32,6 @@ import {
 import { combineValidators, useForm } from "@swan-io/use-form";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
-import { useFlag } from "react-tggl-client";
 import { P, match } from "ts-pattern";
 import {
   AccountLanguage,
@@ -46,7 +44,6 @@ import {
 import { usePermissions } from "../hooks/usePermissions";
 import { accountLanguages, locale, t } from "../utils/i18n";
 import { parsePhoneNumber, prefixPhoneNumber } from "../utils/phone";
-import { projectConfiguration } from "../utils/projectId";
 import { Router } from "../utils/routes";
 import { validateAddressLine } from "../utils/validations";
 import { MembershipCancelConfirmationModal } from "./MembershipCancelConfirmationModal";
@@ -89,7 +86,6 @@ export const MembershipDetailEditor = ({
 }: Props) => {
   const { canUpdateAccountMembership } = usePermissions();
   const [isCancelConfirmationModalOpen, setIsCancelConfirmationModalOpen] = useState(false);
-  const canUseNotificationStack = useFlag("useNotificationStackToSendNewMembershipEmail", false);
 
   const [updateMembership, membershipUpdate] = useMutation(UpdateAccountMembershipDocument);
   const [suspendMembership, membershipSuspension] = useMutation(SuspendAccountMembershipDocument);
@@ -97,14 +93,14 @@ export const MembershipDetailEditor = ({
     ResumeAccountMembershipDocument,
   );
 
-  const [sendAccountMembershipInviteNotification] = useMutation(
+  const [sendAccountMembershipInviteNotification, invitationSending] = useMutation(
     SendAccountMembershipInviteNotificationDocument,
   );
 
   const isEditingCurrentUserAccountMembership =
     currentUserAccountMembership.id === editingAccountMembership.id;
 
-  const { Field, FieldsListener, getFieldValue, setFieldValue, submitForm } = useForm({
+  const { Field, FieldsListener, setFieldValue, submitForm } = useForm({
     email: {
       initialValue: editingAccountMembership.email,
       sanitize: trim,
@@ -388,68 +384,21 @@ export const MembershipDetailEditor = ({
       });
   };
 
-  const [invitationSending, setInvitationSending] = useState<
-    AsyncData<Result<undefined, undefined>>
-  >(AsyncData.NotAsked());
-
   const sendInvitation = () => {
-    if (canUseNotificationStack) {
-      sendAccountMembershipInviteNotification({
-        input: { accountMembershipId: editingAccountMembershipId },
-      })
-        .mapOk(data => data.sendAccountMembershipInviteNotification)
-        .mapOkToResult(filterRejectionsToResult)
-        .tapOk(() => {
-          showToast({
-            variant: "success",
-            title: t("membershipDetail.resendInvitationSuccessToast"),
-          });
-        })
-        .tapError(error => {
-          showToast({ variant: "error", error, title: translateError(error) });
+    sendAccountMembershipInviteNotification({
+      input: { accountMembershipId: editingAccountMembershipId },
+    })
+      .mapOk(data => data.sendAccountMembershipInviteNotification)
+      .mapOkToResult(filterRejectionsToResult)
+      .tapOk(() => {
+        showToast({
+          variant: "success",
+          title: t("membershipDetail.resendInvitationSuccessToast"),
         });
-    } else {
-      setInvitationSending(AsyncData.Loading());
-
-      const query = new URLSearchParams();
-
-      query.append("inviterAccountMembershipId", currentUserAccountMembershipId);
-      query.append("lang", getFieldValue("language"));
-
-      const url = match(projectConfiguration)
-        .with(
-          Option.P.Some({ projectId: P.select(), mode: "MultiProject" }),
-          projectId =>
-            `/api/projects/${projectId}/invitation/${editingAccountMembershipId}/send?${query.toString()}`,
-        )
-        .otherwise(() => `/api/invitation/${editingAccountMembershipId}/send?${query.toString()}`);
-
-      const request = Request.make({
-        url,
-        method: "POST",
-        credentials: "include",
-        type: "json",
-        body: JSON.stringify({
-          inviteeAccountMembershipId: editingAccountMembershipId,
-          inviterAccountMembershipId: currentUserAccountMembershipId,
-        }),
       })
-        .mapOkToResult(badStatusToError)
-        .mapOk(() => undefined)
-        .mapError(() => undefined);
-
-      request
-        .tapError(error => {
-          showToast({ variant: "error", error, title: t("error.generic") });
-        })
-        .onResolve(value => {
-          showToast({
-            variant: "success",
-            title: t("membershipDetail.resendInvitationSuccessToast"),
-          });
-          setInvitationSending(AsyncData.Done(value));
-        });
-    }
+      .tapError(error => {
+        showToast({ variant: "error", error, title: translateError(error) });
+      });
   };
 
   return (

--- a/clients/banking/src/components/MembershipsArea.tsx
+++ b/clients/banking/src/components/MembershipsArea.tsx
@@ -1,4 +1,3 @@
-import { Option } from "@swan-io/boxed";
 import { Link } from "@swan-io/chicane";
 import { useDeferredQuery, useMutation, useQuery } from "@swan-io/graphql-client";
 import { Box } from "@swan-io/lake/src/components/Box";
@@ -12,11 +11,9 @@ import { Space } from "@swan-io/lake/src/components/Space";
 import { commonStyles } from "@swan-io/lake/src/constants/commonStyles";
 import { breakpoints, colors, spacings } from "@swan-io/lake/src/constants/design";
 import { nullishOrEmptyToUndefined } from "@swan-io/lake/src/utils/nullish";
-import { Request } from "@swan-io/request";
 import { LakeModal } from "@swan-io/shared-business/src/components/LakeModal";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { StyleSheet, View } from "react-native";
-import { useFlag } from "react-tggl-client";
 import { P, isMatching, match } from "ts-pattern";
 import { Except } from "type-fest";
 import {
@@ -27,8 +24,7 @@ import {
   SendAccountMembershipInviteNotificationDocument,
 } from "../graphql/partner";
 import { usePermissions } from "../hooks/usePermissions";
-import { locale, t } from "../utils/i18n";
-import { projectConfiguration } from "../utils/projectId";
+import { t } from "../utils/i18n";
 import { RouteParams, Router, membershipsRoutes } from "../utils/routes";
 import { Connection } from "./Connection";
 import { ErrorView } from "./ErrorView";
@@ -81,8 +77,6 @@ export const MembershipsArea = ({
   const { canAddAccountMembership } = usePermissions();
   const [, { query: queryLastCreatedMembership }] = useDeferredQuery(MembershipDetailDocument);
   const route = Router.useRoute(membershipsRoutes);
-
-  const canUseNotificationStack = useFlag("useNotificationStackToSendNewMembershipEmail", false);
 
   const [sendAccountMembershipInviteNotification] = useMutation(
     SendAccountMembershipInviteNotificationDocument,
@@ -160,48 +154,15 @@ export const MembershipsArea = ({
           accountMembershipInvitationMode: "EMAIL",
         },
         ({ params: { resourceId } }) => {
-          queryLastCreatedMembership({ accountMembershipId: resourceId }).tapOk(membership => {
-            if (canUseNotificationStack) {
-              sendAccountMembershipInviteNotification({
-                input: { accountMembershipId: resourceId },
-              });
-            } else {
-              const query = new URLSearchParams();
-              query.append("inviterAccountMembershipId", accountMembershipId);
-              query.append("lang", membership.accountMembership?.language ?? locale.language);
-
-              const url = match(projectConfiguration)
-                .with(
-                  Option.P.Some({ projectId: P.select(), mode: "MultiProject" }),
-                  projectId =>
-                    `/api/projects/${projectId}/invitation/${resourceId}/send?${query.toString()}`,
-                )
-                .otherwise(() => `/api/invitation/${resourceId}/send?${query.toString()}`);
-
-              Request.make({
-                url,
-                method: "POST",
-                type: "text",
-              }).tap(() => {
-                Router.replace("AccountMembersList", {
-                  ...params,
-                  accountMembershipId,
-                  resourceId: undefined,
-                  status: undefined,
-                });
-              });
-            }
+          queryLastCreatedMembership({ accountMembershipId: resourceId }).tapOk(() => {
+            sendAccountMembershipInviteNotification({
+              input: { accountMembershipId: resourceId },
+            });
           });
         },
       )
       .otherwise(() => {});
-  }, [
-    params,
-    accountMembershipId,
-    queryLastCreatedMembership,
-    canUseNotificationStack,
-    sendAccountMembershipInviteNotification,
-  ]);
+  }, [params, queryLastCreatedMembership, sendAccountMembershipInviteNotification]);
 
   return (
     <ResponsiveContainer breakpoint={breakpoints.large} style={styles.root}>

--- a/clients/banking/src/components/NewMembershipWizard.tsx
+++ b/clients/banking/src/components/NewMembershipWizard.tsx
@@ -12,7 +12,6 @@ import { breakpoints, colors, spacings } from "@swan-io/lake/src/constants/desig
 import { filterRejectionsToResult } from "@swan-io/lake/src/utils/gql";
 import { emptyToUndefined, isNullishOrEmpty } from "@swan-io/lake/src/utils/nullish";
 import { trim } from "@swan-io/lake/src/utils/string";
-import { Request, badStatusToError } from "@swan-io/request";
 import { BirthdatePicker } from "@swan-io/shared-business/src/components/BirthdatePicker";
 import { CountryPicker } from "@swan-io/shared-business/src/components/CountryPicker";
 import { InputPhoneNumber } from "@swan-io/shared-business/src/components/InputPhoneNumber";
@@ -36,7 +35,6 @@ import {
 import { combineValidators, useForm } from "@swan-io/use-form";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
-import { useFlag } from "react-tggl-client";
 import { P, match } from "ts-pattern";
 import {
   AccountCountry,
@@ -47,7 +45,6 @@ import {
 } from "../graphql/partner";
 import { accountLanguages, locale, t } from "../utils/i18n";
 import { prefixPhoneNumber } from "../utils/phone";
-import { projectConfiguration } from "../utils/projectId";
 import { Router } from "../utils/routes";
 import { validateAddressLine } from "../utils/validations";
 
@@ -123,8 +120,6 @@ export const NewMembershipWizard = ({
   onSuccess,
   onPressCancel,
 }: Props) => {
-  const canUseNotificationStack = useFlag("useNotificationStackToSendNewMembershipEmail", false);
-
   const [sendAccountMembershipInviteNotification] = useMutation(
     SendAccountMembershipInviteNotificationDocument,
   );
@@ -373,46 +368,12 @@ export const NewMembershipWizard = ({
 
   const sendInvitation = ({
     editingAccountMembershipId,
-    language,
   }: {
     editingAccountMembershipId: string;
-    language: AccountLanguage;
   }) => {
-    const query = new URLSearchParams();
-
-    query.append("inviterAccountMembershipId", currentUserAccountMembership.id);
-    query.append("lang", language);
-
-    if (canUseNotificationStack) {
-      sendAccountMembershipInviteNotification({
-        input: { accountMembershipId: editingAccountMembershipId },
-      });
-    } else {
-      const url = match(projectConfiguration)
-        .with(
-          Option.P.Some({ projectId: P.select(), mode: "MultiProject" }),
-          projectId =>
-            `/api/projects/${projectId}/invitation/${editingAccountMembershipId}/send?${query.toString()}`,
-        )
-        .otherwise(() => `/api/invitation/${editingAccountMembershipId}/send?${query.toString()}`);
-
-      return Request.make({
-        url,
-        method: "POST",
-        credentials: "include",
-        type: "json",
-        body: JSON.stringify({
-          inviteeAccountMembershipId: editingAccountMembershipId,
-          inviterAccountMembershipId: currentUserAccountMembership.id,
-        }),
-      })
-        .mapOkToResult(badStatusToError)
-        .mapOk(() => undefined)
-        .mapError(() => undefined)
-        .tapError(error => {
-          showToast({ variant: "error", error, title: t("error.generic") });
-        });
-    }
+    sendAccountMembershipInviteNotification({
+      input: { accountMembershipId: editingAccountMembershipId },
+    });
   };
 
   const onPressSubmit = () => {
@@ -479,7 +440,7 @@ export const NewMembershipWizard = ({
                 .otherwise(data => {
                   match(__env.ACCOUNT_MEMBERSHIP_INVITATION_MODE)
                     .with("EMAIL", () => {
-                      sendInvitation({ editingAccountMembershipId: data.id, language });
+                      sendInvitation({ editingAccountMembershipId: data.id });
                     })
                     .otherwise(() => {});
 


### PR DESCRIPTION
### Report generated by Claude code once completing the command :

Removed all references to the useNotificationStackToSendNewMembershipEmail flag (default true). For each call site, kept the if 
  (canUseNotificationStack) branch (notification stack via GraphQL mutation) and dropped the legacy REST Request.make fallback.
  
  File: clients/banking/src/components/MembershipDetailEditor.tsx
  Changes: Removed useFlag call, simplified sendInvitation to only invoke the GraphQL mutation, dropped local invitationSending useState and pulled
    the loading flag from the mutation tuple instead. Pruned unused imports: AsyncData, Result (boxed), Request, badStatusToError, useFlag,
    projectConfiguration; removed unused getFieldValue from the useForm destructure.
  Confidence: ⚠️  Review needed — touches the invitation loading UX (loading={invitationSending.isLoading()}); behavior is equivalent but the loading
    source changed from local async state to mutation state.
  ────────────────────────────────────────
  File: clients/banking/src/components/MembershipsArea.tsx
  Changes: Removed useFlag and the legacy URL/Request fallback inside the useEffect. Simplified the deps array (dropped canUseNotificationStack and
    accountMembershipId). Pruned unused imports: Option, Request, locale, projectConfiguration.
  Confidence: ✅ Safe — dead branch removal.
  ────────────────────────────────────────
  File: clients/banking/src/components/NewMembershipWizard.tsx
  Changes: Removed useFlag, simplified sendInvitation to only call the GraphQL mutation; removed its language parameter (no longer needed) and the
    corresponding argument at the call site. Pruned unused imports: Request, badStatusToError, projectConfiguration.
  Confidence: ✅ Safe — dead branch removal.

  Verification: pnpm typecheck runs clean.

  🧪 How to test it
  - Open banking.swan.local and go to Members.
  - Invite a new member from the list (the “New” modal): the new member should receive the invitation email after submission.
  - On an existing member with an Invitation sent status, open the right panel and press Resend invitation: a success toast should appear and the
  member should receive a new invitation email.
  - After a member accepts via the magic link, the ?status=Accepted&resourceId=… URL flow should still trigger a follow-up invitation email when
  ACCOUNT_MEMBERSHIP_INVITATION_MODE=EMAIL.