### PR TITLE
v1.34.2

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- Add biome rules (#1645)
- add session tracking in grafana faro (#1646)
- ci(deploy-swan): use github app to sign commits (#1649)
- fix: target npm public registry (#1650)
- upgrade fastify/static (#1651)
- Update spain tax id rules (#1653)
- add feature flag to start v1 or v2 onboarding by default (#1652)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.34.1..release-v1.34.2