### PR TITLE
v1.36.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.35.3",
+  "version": "1.36.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.35.3",
+  "version": "1.36.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.35.3",
+  "version": "1.36.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.35.3",
+  "version": "1.36.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.35.3",
+  "version": "1.36.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- update translations from localazy (#1686)
- fix: restore access to account switcher menu on mobile (#1688)
- chore: improve error message from backend and partial filled inputs (#1687)
- add error message when ICT exceed max amount (#1681)
- chore: CODEOWNERS management via terraform
- Front 1940 nudge self invitation on change account admin portal (#1690)
- add tracking on company onboarding first step (#1691)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.35.3..release-v1.36.0