### PR TITLE
v1.36.2

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- chore: upgrade lake dependency (#1699)
- refactor(cards): separate single-use spending-limit logic from regular (#1696)
- Fix cve (#1701)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.36.1..release-v1.36.2