### PR TITLE
v1.36.5

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.36.4",
+  "version": "1.36.5",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- remove QEMU and build amd64 images (#1700)
- chore(banking): skip user not found error when expected (#1707)
- Front 1971 update rules upload s3 (#1708)
- fix(rekyc): normalize cca2 country codes to cca3 for address country (#1709)
- replace tggl client by API call on server side (#1710)
- chore(banking): use pollUntilOk from lake (#1711)
- Update rules for s3 and add form action (#1712)
- clean code in account activation page (#1713)
- fix posthog pageview tracking (#1714)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.36.4..release-v1.36.5