### PR TITLE
v1.38.0

### DIFF
--- a/clients/banking/package.json
+++ b/clients/banking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/banking",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/onboarding/package.json
+++ b/clients/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/onboarding",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/clients/payment/package.json
+++ b/clients/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swan-io/payment",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/partner-frontend",
   "description": "Swan front-end code",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swan-io/frontend-server",
   "description": "Swan frontend server",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {


### PR DESCRIPTION
### What's Included

- Fix connect src for dev (#1736)
- upgrade to typescript 7 (#1738)
- setup knip and clean deadcode (#1737)
- Remove matomo in onboarding (#1739)
- chore: use toSorted() from the javascript API (#1740)
- fix CVE-2026-9277 (#1741)
- add AdditionalAccountSubscription translations (#1742)
- upgrade lake and fix permissions tag (#1744)
- fetch rekyc info for suspended cases (#1745)
- Setup metrics (#1746)
- remove jaeger propagator (#1747)
- add validation rule on creditor identifier (#1748)
- sanitize creditor identifier (#1749)

**Diff**: https://github.com/swan-io/swan-partner-frontend/compare/v1.37.4..release-v1.38.0