### PR TITLE
Add log redaction for onboarding

### DIFF
--- a/clients/onboarding/src/App.tsx
+++ b/clients/onboarding/src/App.tsx
@@ -84,14 +84,15 @@ const FlowPicker = ({ onboardingId }: Props) => {
           .exhaustive(() => undefined);
 
         if (projectId != null && accountCountry != null && onboardingType != null) {
-          logger.setContext({
-            onboardingVersion: "v1",
-            accountCountry,
-            projectId,
-            onboardingId,
-            onboardingType,
-          });
-          logPageView(); // log initial pageview just after setting the context
+          void logger
+            .setContext({
+              onboardingVersion: "v1",
+              accountCountry,
+              projectId,
+              onboardingId,
+              onboardingType,
+            })
+            .then(logPageView); // log initial pageview just after setting the context
         }
       })
       .otherwise(() => {});
@@ -206,18 +207,19 @@ const FlowPickerV2 = ({ onboardingId }: Props) => {
       ({ publicAccountHolderOnboarding }) => {
         match(publicAccountHolderOnboarding)
           .with(P.nonNullable, onboarding => {
-            logger.setContext({
-              onboardingVersion: "v2",
-              accountCountry: onboarding.accountInfo?.country ?? "FRA",
-              onboardingId: onboarding.id,
-              projectId: onboarding.projectInfo.id,
-              onboardingType: match(onboarding.__typename)
-                .returnType<"Company" | "Individual">()
-                .with("CompanyAccountHolderOnboarding", () => "Company")
-                .with("IndividualAccountHolderOnboarding", () => "Individual")
-                .exhaustive(),
-            });
-            logPageView(); // log initial pageview just after setting the context
+            void logger
+              .setContext({
+                onboardingVersion: "v2",
+                accountCountry: onboarding.accountInfo?.country ?? "FRA",
+                onboardingId: onboarding.id,
+                projectId: onboarding.projectInfo.id,
+                onboardingType: match(onboarding.__typename)
+                  .returnType<"Company" | "Individual">()
+                  .with("CompanyAccountHolderOnboarding", () => "Company")
+                  .with("IndividualAccountHolderOnboarding", () => "Individual")
+                  .exhaustive(),
+              })
+              .then(logPageView); // log initial pageview just after setting the context
 
             if (onboarding.accountAdmin?.preferredLanguage === locale.language) {
               return;

--- a/clients/onboarding/src/App.tsx
+++ b/clients/onboarding/src/App.tsx
@@ -84,15 +84,14 @@ const FlowPicker = ({ onboardingId }: Props) => {
           .exhaustive(() => undefined);
 
         if (projectId != null && accountCountry != null && onboardingType != null) {
-          void logger
-            .setContext({
-              onboardingVersion: "v1",
-              accountCountry,
-              projectId,
-              onboardingId,
-              onboardingType,
-            })
-            .then(logPageView); // log initial pageview just after setting the context
+          logger.setContext({
+            onboardingVersion: "v1",
+            accountCountry,
+            projectId,
+            onboardingId,
+            onboardingType,
+          });
+          logPageView(); // log initial pageview just after setting the context
         }
       })
       .otherwise(() => {});
@@ -207,19 +206,18 @@ const FlowPickerV2 = ({ onboardingId }: Props) => {
       ({ publicAccountHolderOnboarding }) => {
         match(publicAccountHolderOnboarding)
           .with(P.nonNullable, onboarding => {
-            void logger
-              .setContext({
-                onboardingVersion: "v2",
-                accountCountry: onboarding.accountInfo?.country ?? "FRA",
-                onboardingId: onboarding.id,
-                projectId: onboarding.projectInfo.id,
-                onboardingType: match(onboarding.__typename)
-                  .returnType<"Company" | "Individual">()
-                  .with("CompanyAccountHolderOnboarding", () => "Company")
-                  .with("IndividualAccountHolderOnboarding", () => "Individual")
-                  .exhaustive(),
-              })
-              .then(logPageView); // log initial pageview just after setting the context
+            logger.setContext({
+              onboardingVersion: "v2",
+              accountCountry: onboarding.accountInfo?.country ?? "FRA",
+              onboardingId: onboarding.id,
+              projectId: onboarding.projectInfo.id,
+              onboardingType: match(onboarding.__typename)
+                .returnType<"Company" | "Individual">()
+                .with("CompanyAccountHolderOnboarding", () => "Company")
+                .with("IndividualAccountHolderOnboarding", () => "Individual")
+                .exhaustive(),
+            });
+            logPageView(); // log initial pageview just after setting the context
 
             if (onboarding.accountAdmin?.preferredLanguage === locale.language) {
               return;

--- a/clients/onboarding/src/pages/v2/company/OnboardingCompanyRoot.tsx
+++ b/clients/onboarding/src/pages/v2/company/OnboardingCompanyRoot.tsx
@@ -118,12 +118,12 @@ export const OnboardingCompanyRoot = ({ onboarding, serverValidationErrors }: Pr
   const [representatives, setRepresentatives] = useState(related.length > 0 ? related : undefined);
 
   const resetToManualMode = useCallback(() => {
-    logger.event("set_manual_mode", { onboardingId, from: "search_company_dropdown" });
+    logger.event("set_manual_mode", { from: "search_company_dropdown" });
     setManualMode(true);
     setRepresentatives(undefined);
     hasOnboardingPrefilled.delete();
     setPublicData(undefined);
-  }, [onboardingId]);
+  }, []);
 
   const { Field, FieldsListener, setFieldValue, setFieldError, submitForm } = useForm({
     name: {
@@ -181,7 +181,7 @@ export const OnboardingCompanyRoot = ({ onboarding, serverValidationErrors }: Pr
 
         if (isNullish(currentValues.legalFormCode)) {
           setManualMode(true);
-          logger.event("set_manual_mode", { onboardingId, from: "submit_without_legalFormCode" });
+          logger.event("set_manual_mode", { from: "submit_without_legalFormCode" });
           return;
         }
 

--- a/clients/onboarding/src/pages/v2/company/OnboardingCompanyRoot.tsx
+++ b/clients/onboarding/src/pages/v2/company/OnboardingCompanyRoot.tsx
@@ -48,6 +48,7 @@ import {
 import { locale, t } from "../../../utils/i18n";
 import { cleanData, transformRelatedIndividualsToInput } from "../../../utils/onboarding";
 import { CompanySuggestion } from "../../../utils/Pappers";
+import { maskUuid } from "../../../utils/redaction";
 import { Router } from "../../../utils/routes";
 import { hasOnboardingPrefilled } from "../../../utils/session";
 import { getUpdateOnboardingError } from "../../../utils/templateTranslations";
@@ -118,12 +119,15 @@ export const OnboardingCompanyRoot = ({ onboarding, serverValidationErrors }: Pr
   const [representatives, setRepresentatives] = useState(related.length > 0 ? related : undefined);
 
   const resetToManualMode = useCallback(() => {
-    logger.event("set_manual_mode", { from: "search_company_dropdown" });
+    logger.event("set_manual_mode", {
+      onboardingId: maskUuid(onboardingId),
+      from: "search_company_dropdown",
+    });
     setManualMode(true);
     setRepresentatives(undefined);
     hasOnboardingPrefilled.delete();
     setPublicData(undefined);
-  }, []);
+  }, [onboardingId]);
 
   const { Field, FieldsListener, setFieldValue, setFieldError, submitForm } = useForm({
     name: {
@@ -181,7 +185,10 @@ export const OnboardingCompanyRoot = ({ onboarding, serverValidationErrors }: Pr
 
         if (isNullish(currentValues.legalFormCode)) {
           setManualMode(true);
-          logger.event("set_manual_mode", { from: "submit_without_legalFormCode" });
+          logger.event("set_manual_mode", {
+            onboardingId: maskUuid(onboardingId),
+            from: "submit_without_legalFormCode",
+          });
           return;
         }
 

--- a/clients/onboarding/src/utils/__tests__/redaction.test.ts
+++ b/clients/onboarding/src/utils/__tests__/redaction.test.ts
@@ -1,9 +1,9 @@
-import { Option } from "@swan-io/boxed";
-import { expect, test, vi } from "vitest";
-import { hashIdentifier, sanitizePathname, sanitizeProperties, sanitizeUrl } from "../redaction";
+import { expect, test } from "vitest";
+import { maskUuid, sanitizePathname, sanitizeProperties, sanitizeUrl } from "../redaction";
 
 const ONBOARDING_ID = "3f2b8c1a-4d5e-4f60-9a7b-1c2d3e4f5a6b";
 const COLLECTION_ID = "9E4B7C2D-1A3F-4B5C-8D6E-7F809A1B2C3D";
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 test("sanitizePathname replaces identifier segments", () => {
   expect(sanitizePathname(`/onboardings/${ONBOARDING_ID}/documents`)).toBe(
@@ -71,21 +71,13 @@ test("sanitizeProperties leaves non-string values untouched", () => {
   });
 });
 
-test("hashIdentifier is deterministically", async () => {
-  await expect(hashIdentifier(ONBOARDING_ID)).resolves.toStrictEqual(
-    Option.Some("cdabd615e370b6e48383f8ccd98cd937"),
-  );
-  await expect(hashIdentifier(COLLECTION_ID)).resolves.toStrictEqual(
-    Option.Some("0e3e467ab57494e38822e1860ad5370a"),
-  );
+test("maskUuid keeps only the last group", () => {
+  expect(maskUuid(ONBOARDING_ID)).toBe("********-****-****-****-1c2d3e4f5a6b");
+  expect(maskUuid(COLLECTION_ID)).toBe("********-****-****-****-7F809A1B2C3D");
 });
 
-test("hashIdentifier yields None rather than the raw identifier when crypto is unavailable", async () => {
-  vi.stubGlobal("crypto", {});
-
-  try {
-    await expect(hashIdentifier(ONBOARDING_ID)).resolves.toStrictEqual(Option.None());
-  } finally {
-    vi.unstubAllGlobals();
-  }
+test("maskUuid masks anything that is not a uuid whole", () => {
+  expect(maskUuid("consent-challenge-SECRETVALUE")).toBe("*****************************");
+  expect(maskUuid("abcdef123456")).toBe("************");
+  expect(maskUuid("")).toBe("");
 });

--- a/clients/onboarding/src/utils/__tests__/redaction.test.ts
+++ b/clients/onboarding/src/utils/__tests__/redaction.test.ts
@@ -1,0 +1,92 @@
+import { Option } from "@swan-io/boxed";
+import { expect, test, vi } from "vitest";
+import { hashIdentifier, sanitizePathname, sanitizeProperties, sanitizeUrl } from "../redaction";
+
+const ONBOARDING_ID = "3f2b8c1a-4d5e-4f60-9a7b-1c2d3e4f5a6b";
+const COLLECTION_ID = "9E4B7C2D-1A3F-4B5C-8D6E-7F809A1B2C3D";
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+test("sanitizePathname replaces identifier segments", () => {
+  expect(sanitizePathname(`/onboardings/${ONBOARDING_ID}/documents`)).toBe(
+    "/onboardings/<id>/documents",
+  );
+  expect(sanitizePathname(`/supporting-document-collection/${COLLECTION_ID}/success`)).toBe(
+    "/supporting-document-collection/<id>/success",
+  );
+  expect(sanitizePathname(`/projects/${ONBOARDING_ID}/onboardings/${ONBOARDING_ID}`)).toBe(
+    "/projects/<id>/onboardings/<id>",
+  );
+});
+
+test("sanitizePathname replaces opaque tokens", () => {
+  expect(sanitizePathname("/invitation/aGVsbG8tdGhlcmUtZnJpZW5kMTIz")).toBe("/invitation/<id>");
+});
+
+test("sanitizePathname keeps route segments", () => {
+  expect(sanitizePathname("/power-of-attorney-template/en-1.pdf")).toBe(
+    "/power-of-attorney-template/en-1.pdf",
+  );
+  expect(sanitizePathname("/")).toBe("/");
+});
+
+test("sanitizeUrl strips identifiers, query strings and fragments", () => {
+  expect(sanitizeUrl(`https://onboarding.swan.io/onboardings/${ONBOARDING_ID}/email`)).toBe(
+    "https://onboarding.swan.io/onboardings/<id>/email",
+  );
+  expect(
+    sanitizeUrl(`https://onboarding.swan.io/onboardings/${ONBOARDING_ID}?consent_challenge=abc`),
+  ).toBe("https://onboarding.swan.io/onboardings/<id>");
+  expect(sanitizeUrl("https://onboarding.swan.io/x#login_challenge=abc")).toBe(
+    "https://onboarding.swan.io/x",
+  );
+  expect(sanitizeUrl("not a url")).toBe("<invalid-url>");
+});
+
+test("sanitizeProperties scrubs every url-shaped value", () => {
+  const properties = {
+    $current_url: `https://onboarding.swan.io/onboardings/${ONBOARDING_ID}`,
+    $initial_current_url: `https://onboarding.swan.io/onboardings/${ONBOARDING_ID}`,
+    $referrer: `https://onboarding.swan.io/onboardings/${ONBOARDING_ID}/email`,
+    $pathname: `/onboardings/${ONBOARDING_ID}`,
+    $initial_pathname: `/onboardings/${ONBOARDING_ID}`,
+    $host: "onboarding.swan.io",
+    application: "onboarding",
+  };
+
+  expect(sanitizeProperties(properties)).toStrictEqual({
+    $current_url: "https://onboarding.swan.io/onboardings/<id>",
+    $initial_current_url: "https://onboarding.swan.io/onboardings/<id>",
+    $referrer: "https://onboarding.swan.io/onboardings/<id>/email",
+    $pathname: "/onboardings/<id>",
+    $initial_pathname: "/onboardings/<id>",
+    $host: "onboarding.swan.io",
+    application: "onboarding",
+  });
+});
+
+test("sanitizeProperties leaves non-string values untouched", () => {
+  expect(sanitizeProperties({ count: 1, flag: true, missing: null })).toStrictEqual({
+    count: 1,
+    flag: true,
+    missing: null,
+  });
+});
+
+test("hashIdentifier is deterministically", async () => {
+  await expect(hashIdentifier(ONBOARDING_ID)).resolves.toStrictEqual(
+    Option.Some("cdabd615e370b6e48383f8ccd98cd937"),
+  );
+  await expect(hashIdentifier(COLLECTION_ID)).resolves.toStrictEqual(
+    Option.Some("0e3e467ab57494e38822e1860ad5370a"),
+  );
+});
+
+test("hashIdentifier yields None rather than the raw identifier when crypto is unavailable", async () => {
+  vi.stubGlobal("crypto", {});
+
+  try {
+    await expect(hashIdentifier(ONBOARDING_ID)).resolves.toStrictEqual(Option.None());
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});

--- a/clients/onboarding/src/utils/__tests__/redaction.test.ts
+++ b/clients/onboarding/src/utils/__tests__/redaction.test.ts
@@ -3,7 +3,6 @@ import { maskUuid, sanitizePathname, sanitizeProperties, sanitizeUrl } from "../
 
 const ONBOARDING_ID = "3f2b8c1a-4d5e-4f60-9a7b-1c2d3e4f5a6b";
 const COLLECTION_ID = "9E4B7C2D-1A3F-4B5C-8D6E-7F809A1B2C3D";
-const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 test("sanitizePathname replaces identifier segments", () => {
   expect(sanitizePathname(`/onboardings/${ONBOARDING_ID}/documents`)).toBe(

--- a/clients/onboarding/src/utils/__tests__/redaction.test.ts
+++ b/clients/onboarding/src/utils/__tests__/redaction.test.ts
@@ -4,7 +4,6 @@ import { hashIdentifier, sanitizePathname, sanitizeProperties, sanitizeUrl } fro
 
 const ONBOARDING_ID = "3f2b8c1a-4d5e-4f60-9a7b-1c2d3e4f5a6b";
 const COLLECTION_ID = "9E4B7C2D-1A3F-4B5C-8D6E-7F809A1B2C3D";
-const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 test("sanitizePathname replaces identifier segments", () => {
   expect(sanitizePathname(`/onboardings/${ONBOARDING_ID}/documents`)).toBe(

--- a/clients/onboarding/src/utils/logger.ts
+++ b/clients/onboarding/src/utils/logger.ts
@@ -1,17 +1,6 @@
 import posthog from "posthog-js";
 import { env } from "./env";
-
-const replaceIdInPath = (path: string) => {
-  return path
-    .split("/")
-    .map(segment => {
-      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        segment,
-      );
-      return isUuid ? "<id>" : segment;
-    })
-    .join("/");
-};
+import { sanitizeProperties } from "./redaction";
 
 export const initPostHog = () => {
   if (import.meta.env.PROD && env.IS_SWAN_MODE) {
@@ -26,9 +15,12 @@ export const initPostHog = () => {
       api_host: "https://eu.i.posthog.com",
       defaults: "2025-05-24",
       before_send: event => {
-        if (event?.properties.$pathname != null) {
-          event.properties.$pathname = replaceIdInPath(event.properties.$pathname);
+        if (event == null) {
+          return event;
         }
+
+        // PostHog attaches $current_url, $referrer and their $initial_, so scrub the whole property
+        event.properties = sanitizeProperties(event.properties);
 
         return event;
       },

--- a/clients/onboarding/src/utils/logger.ts
+++ b/clients/onboarding/src/utils/logger.ts
@@ -15,13 +15,10 @@ export const initPostHog = () => {
       api_host: "https://eu.i.posthog.com",
       defaults: "2025-05-24",
       before_send: event => {
-        if (event == null) {
-          return event;
+        if (event != null) {
+          // PostHog attaches $current_url, $referrer and their $initial_, so scrub the whole property
+          event.properties = sanitizeProperties(event.properties);
         }
-
-        // PostHog attaches $current_url, $referrer and their $initial_, so scrub the whole property
-        event.properties = sanitizeProperties(event.properties);
-
         return event;
       },
 

--- a/clients/onboarding/src/utils/redaction.ts
+++ b/clients/onboarding/src/utils/redaction.ts
@@ -1,5 +1,3 @@
-import { Option } from "@swan-io/boxed";
-
 /*
  * Redaction utilty for our logger
  */
@@ -42,20 +40,7 @@ export const sanitizeProperties = <T>(properties: Record<string, T>): Record<str
     }),
   );
 
-// Hash id so telemetry can correlate a funnel without holding the raw id
-export const hashIdentifier = (value: string): Promise<Option<string>> => {
-  if (typeof crypto?.subtle?.digest !== "function") {
-    return Promise.resolve(Option.None());
-  }
-
-  return crypto.subtle
-    .digest("SHA-256", new TextEncoder().encode(value))
-    .then(digest =>
-      Option.Some(
-        Array.from(new Uint8Array(digest).slice(0, 16))
-          .map(byte => byte.toString(16).padStart(2, "0"))
-          .join(""),
-      ),
-    )
-    .catch(() => Option.None());
-};
+// Mask a uuid so telemetry can correlate a funnel without holding the raw id.
+// Anything that isn't a uuid is masked whole: that reasoning only holds here,
+export const maskUuid = (value: string) =>
+  UUID.test(value) ? `********-****-****-****-${value.slice(-12)}` : "*".repeat(value.length);

--- a/clients/onboarding/src/utils/redaction.ts
+++ b/clients/onboarding/src/utils/redaction.ts
@@ -1,0 +1,61 @@
+import { Option } from "@swan-io/boxed";
+
+/*
+ * Redaction utilty for our logger
+ */
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const OPAQUE_TOKEN = /^(?=.*[A-Z0-9])[A-Za-z0-9_-]{20,}$/;
+
+const isIdentifier = (segment: string) => UUID.test(segment) || OPAQUE_TOKEN.test(segment);
+
+export const sanitizePathname = (pathname: string) =>
+  pathname
+    .split("/")
+    .map(segment => (isIdentifier(segment) ? "<id>" : segment))
+    .join("/");
+
+export const sanitizeUrl = (url: string) => {
+  try {
+    const { origin, pathname } = new URL(url);
+    return `${origin}${sanitizePathname(pathname)}`;
+  } catch {
+    return "<invalid-url>";
+  }
+};
+
+const isUrl = (value: string) => value.startsWith("https://") || value.startsWith("http://");
+
+export const sanitizeProperties = <T>(properties: Record<string, T>): Record<string, T | string> =>
+  Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => {
+      if (typeof value !== "string") {
+        return [key, value];
+      }
+      if (isUrl(value)) {
+        return [key, sanitizeUrl(value)];
+      }
+      if (key.endsWith("pathname")) {
+        return [key, sanitizePathname(value)];
+      }
+      return [key, value];
+    }),
+  );
+
+// Hash id so telemetry can correlate a funnel without holding the raw id
+export const hashIdentifier = (value: string): Promise<Option<string>> => {
+  if (typeof crypto?.subtle?.digest !== "function") {
+    return Promise.resolve(Option.None());
+  }
+
+  return crypto.subtle
+    .digest("SHA-256", new TextEncoder().encode(value))
+    .then(digest =>
+      Option.Some(
+        Array.from(new Uint8Array(digest).slice(0, 16))
+          .map(byte => byte.toString(16).padStart(2, "0"))
+          .join(""),
+      ),
+    )
+    .catch(() => Option.None());
+};

--- a/clients/onboarding/src/utils/tracing.ts
+++ b/clients/onboarding/src/utils/tracing.ts
@@ -5,6 +5,7 @@ import { match, P } from "ts-pattern";
 import { AccountCountry } from "../graphql/partner";
 import { env } from "./env";
 import { posthogLogger } from "./logger";
+import { hashIdentifier, sanitizePathname, sanitizeUrl } from "./redaction";
 
 let faro: Faro | null = null;
 
@@ -30,6 +31,22 @@ if (environment != null) {
       persistent: true,
     },
 
+    // Faro re-reads location.href into page meta for every signal, so the
+    // scrubbing done in logPageView is not enough on its own.
+    pageTracking: {
+      generatePageId: location => sanitizePathname(location.pathname),
+    },
+
+    beforeSend: item => ({
+      ...item,
+      meta: {
+        ...item.meta,
+        ...(item.meta.page != null && {
+          page: { ...item.meta.page, url: sanitizeUrl(item.meta.page.url ?? "") },
+        }),
+      },
+    }),
+
     instrumentations: [
       ...getWebInstrumentations({
         // disable capture console to control logs we send to Faro with logger.info/warn/error
@@ -42,17 +59,7 @@ if (environment != null) {
 }
 
 export const logPageView = () => {
-  const pathname = window.location.pathname
-    .split("/")
-    .map(segment => {
-      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        segment,
-      );
-      return isUuid ? "<id>" : segment;
-    })
-    .join("/");
-
-  logger.event("pageview", { pathname });
+  logger.event("pageview", { pathname: sanitizePathname(window.location.pathname) });
 };
 
 subscribeToLocation(() => {
@@ -68,9 +75,14 @@ type TrackingContext = {
 };
 
 export const logger = {
-  setContext: (context: TrackingContext) => {
-    faro?.api.setUser({ attributes: context });
-    posthogLogger.setContext(context);
+  // Replace raw onboardingId with hashed onboardingId
+  setContext: async ({ onboardingId, ...context }: TrackingContext) => {
+    const attributes = (await hashIdentifier(onboardingId)).match({
+      Some: onboardingIdHash => ({ ...context, onboardingIdHash }),
+      None: () => context,
+    });
+    faro?.api.setUser({ attributes });
+    posthogLogger.setContext(attributes);
   },
   event: (name: string, properties?: Record<string, string>) => {
     faro?.api.pushEvent(name, properties);

--- a/clients/onboarding/src/utils/tracing.ts
+++ b/clients/onboarding/src/utils/tracing.ts
@@ -5,7 +5,7 @@ import { match, P } from "ts-pattern";
 import { AccountCountry } from "../graphql/partner";
 import { env } from "./env";
 import { posthogLogger } from "./logger";
-import { hashIdentifier, sanitizePathname, sanitizeUrl } from "./redaction";
+import { maskUuid, sanitizePathname, sanitizeUrl } from "./redaction";
 
 let faro: Faro | null = null;
 
@@ -75,12 +75,10 @@ type TrackingContext = {
 };
 
 export const logger = {
-  // Replace raw onboardingId with hashed onboardingId
-  setContext: async ({ onboardingId, ...context }: TrackingContext) => {
-    const attributes = (await hashIdentifier(onboardingId)).match({
-      Some: onboardingIdHash => ({ ...context, onboardingIdHash }),
-      None: () => context,
-    });
+  // Replace raw onboardingId with masked onboardingId
+  setContext: ({ onboardingId, ...context }: TrackingContext) => {
+    const attributes = { ...context, onboardingId: maskUuid(onboardingId) };
+
     faro?.api.setUser({ attributes });
     posthogLogger.setContext(attributes);
   },


### PR DESCRIPTION
In Faro and posthog:
- Redact all onboardingId and collectionid in url
- Add masked onboardingId into tracing context